### PR TITLE
Fix: Update CodeQL workflow to use master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron: '30 1 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
Update the CodeQL workflow to use 'master' branch instead of 'main' to match the repository's default branch.