### PR TITLE
Potential fix for code scanning alert no. 5: Encryption using ECB

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/StringHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/StringHelper.cs
@@ -24,12 +24,17 @@ internal static class StringHelper
         var dataArray = Convert.FromBase64String(data);
 
         using var tDes = TripleDES.Create();
-        tDes.Mode = CipherMode.ECB;
-        tDes.Key = Encoding.UTF8.GetBytes(key);
+        tDes.Mode = CipherMode.CBC;
         tDes.Padding = PaddingMode.PKCS7;
+        tDes.Key = Encoding.UTF8.GetBytes(key).Length >= 24 ? Encoding.UTF8.GetBytes(key)[..24] : throw new ArgumentException("Key must be at least 24 bytes for TripleDES");
+
+        // The first 8 bytes are the IV
+        var iv = new byte[8];
+        Array.Copy(dataArray, 0, iv, 0, iv.Length);
+        tDes.IV = iv;
 
         using var cTransform = tDes.CreateDecryptor();
-        var resultArray = cTransform.TransformFinalBlock(dataArray, 0, dataArray.Length);
+        var resultArray = cTransform.TransformFinalBlock(dataArray, iv.Length, dataArray.Length - iv.Length);
         tDes.Clear();
 
         return Encoding.UTF8.GetString(resultArray);
@@ -46,14 +51,20 @@ internal static class StringHelper
         var dataArray = Encoding.UTF8.GetBytes(data);
 
         using var tDes = TripleDES.Create();
-        tDes.Mode = CipherMode.ECB;
-        tDes.Key = Encoding.UTF8.GetBytes(key);
+        tDes.Mode = CipherMode.CBC;
+        tDes.Key = Encoding.UTF8.GetBytes(key).Length >= 24 ? Encoding.UTF8.GetBytes(key)[..24] : throw new ArgumentException("Key must be at least 24 bytes for TripleDES");
+        tDes.GenerateIV();
         tDes.Padding = PaddingMode.PKCS7;
 
         using var cTransform = tDes.CreateEncryptor();
         var resultArray = cTransform.TransformFinalBlock(dataArray, 0, dataArray.Length);
         tDes.Clear();
 
-        return Convert.ToBase64String(resultArray, 0, resultArray.Length);
+        // Combine IV and ciphertext
+        var ivAndCipher = new byte[tDes.IV.Length + resultArray.Length];
+        Array.Copy(tDes.IV, 0, ivAndCipher, 0, tDes.IV.Length);
+        Array.Copy(resultArray, 0, ivAndCipher, tDes.IV.Length, resultArray.Length);
+
+        return Convert.ToBase64String(ivAndCipher, 0, ivAndCipher.Length);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Corsinvest/cv4pve-api-dotnet/security/code-scanning/5](https://github.com/Corsinvest/cv4pve-api-dotnet/security/code-scanning/5)

The best way to fix this problem is to replace the use of `CipherMode.ECB` with a secure mode, such as CBC (Cipher Block Chaining). CBC requires an initialization vector (IV), which needs to be randomly generated for encryption and provided for decryption. The IV does **not** need to be kept secret, but must be unique for each encryption with the same key, and should be stored along with the ciphertext or transmitted alongside it (typically by prepending its bytes to the ciphertext). 

The required code changes:
- Replace `CipherMode.ECB` with `CipherMode.CBC` in both `Encrypt` and `Decrypt`.
- For `Encrypt`, generate a random IV, set it on the cipher, and prepend the IV to the ciphertext when returning as base64.
- For `Decrypt`, extract the IV from the first block of the decoded ciphertext, set it on the cipher, and decrypt the rest.
- Ensure that the key and IV lengths match the requirements of TripleDES (key 24 bytes, IV 8 bytes).
- No new external dependencies are required; only adjustments to how encrypted data is packaged and handled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
