### PR TITLE
chore: cleanup, add --log-level, GeneratedRegex, rename *Int to *Info, drop NET7 guards, bump v9.1.13

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.12</Version>
+        <Version>9.1.13</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>

--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/CommandOptionExtension.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/CommandOptionExtension.cs
@@ -48,9 +48,12 @@ For more information visit https://www.corsinvest.it/cv4pve";
     /// Get LogLevel from debug
     /// </summary>
     public static LogLevel GetLogLevelFromDebug(this Command command)
-        => command.DebugIsActive()
-            ? LogLevel.Trace
-            : LogLevel.Warning;
+    {
+        var logLevel = command.GetValue(command.GetOption<LogLevel?>($"--{LogLevelOptionName}"));
+        return logLevel ?? (command.DebugIsActive()
+                ? LogLevel.Debug
+                : LogLevel.Warning);
+    }
 
     /// <summary>
     /// Debug option
@@ -58,6 +61,18 @@ For more information visit https://www.corsinvest.it/cv4pve";
     public static Option<bool> AddDebugOption(this Command command)
     {
         var opt = command.AddOption<bool>($"--{DebugOptionName}", "Debug application");
+        opt.Hidden = true;
+        opt.Recursive = true;
+
+        return opt;
+    }
+
+    /// <summary>
+    /// Log level option
+    /// </summary>
+    public static Option<LogLevel?> AddLogLevelOption(this Command command)
+    {
+        var opt = command.AddOption<LogLevel?>($"--{LogLevelOptionName}", "Log level (Trace, Debug, Information, Warning, Error, Critical)");
         opt.Hidden = true;
         opt.Recursive = true;
 
@@ -95,10 +110,10 @@ For more information visit https://www.corsinvest.it/cv4pve";
 -vmid,-name,-@node-???,-@tag-?? exclude from list (e.g. @all,-200,-TestUbuntu,-@tag-customer1)
 range 100:107,-105,200:204
 '@pool-???' for all VM/CT in specific pool (e.g. @pool-customer1),
-'@tag-???' for all VM/CT in specific tags (e.g. @tag-customerA),
+'@tag-???' for all VM/CT with specific tag (e.g. @tag-customerA),
 '@node-???' for all VM/CT in specific node (e.g. @node-pve1, @node-\$(hostname)),
-'@all-???' for all VM/CT in specific host (e.g. @all-pve1, @all-\$(hostname)),
-'@all' for all VM/CT in cluster";
+'@all-???' or 'all-???' for all VM/CT in specific host (e.g. @all-pve1, all-pve1),
+'@all' or 'all' for all VM/CT in cluster";
 
         return opt;
     }
@@ -191,6 +206,11 @@ range 100:107,-105,200:204
     /// Password option
     /// </summary>
     public static readonly string DebugOptionName = "debug";
+
+    /// <summary>
+    /// Log level option
+    /// </summary>
+    public static readonly string LogLevelOptionName = "log-level";
 
     /// <summary>
     /// Dry run
@@ -349,7 +369,6 @@ range 100:107,-105,200:204
         return option;
     }
 
-#if !NETSTANDARD
     /// <summary>
     /// Add validator range
     /// </summary>
@@ -366,104 +385,6 @@ range 100:107,-105,200:204
 
         return option;
     }
-#else
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<int> AddValidatorRange(this Option<int> option, int min, int max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<long> AddValidatorRange(this Option<long> option, long min, long max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<short> AddValidatorRange(this Option<short> option, short min, short max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<byte> AddValidatorRange(this Option<byte> option, byte min, byte max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<float> AddValidatorRange(this Option<float> option, float min, float max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-    /// <summary>
-    /// Add validator range
-    /// </summary>
-    public static Option<double> AddValidatorRange(this Option<double> option, double min, double max)
-    {
-        option.Validators.Add(e =>
-        {
-            var range = e.GetValueOrDefault<int>();
-            if (range < min || range > max)
-            {
-                e.AddError($"Option {e.Tokens.Single().Value} whit value '{range}' is not in range!");
-            }
-        });
-
-        return option;
-    }
-#endif
     /// <summary>
     /// Add validator exist file
     /// </summary>

--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
@@ -121,11 +121,12 @@ Good job";
     /// <summary>
     /// Create console application.
     /// </summary>
-    public static RootCommand CreateApp(string name, string description)
+    public static RootCommand CreateApp(string description)
     {
         var rc = new RootCommand(description);
         rc.AddFullNameLogo();
         rc.AddDebugOption();
+        rc.AddLogLevelOption();
         rc.AddDryRunOption();
         rc.AddLoginOptions();
 
@@ -165,7 +166,7 @@ Good job";
 
             if (rootCommand.DebugIsActive())
             {
-                logger.LogError(ex, ex.Message);
+                logger.LogError(ex, "{Message}", ex.Message);
 
                 System.Console.Out.WriteLine("================ EXCEPTION ================ ");
                 System.Console.Out.WriteLine(ex.GetType().FullName);

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/ModelsExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/ModelsExtensions.cs
@@ -19,8 +19,8 @@ public static class ModelsExtensions
     /// <summary>
     /// Resources index (cluster wide).
     /// </summary>
-    public static async Task<IEnumerable<ClusterResource>> GetAsync(this PveClient.PveCluster.PveResources item, ClusterResourceType resourceType)
-        => await item.GetAsync(resourceType switch
+    public static Task<IEnumerable<ClusterResource>> GetAsync(this PveClient.PveCluster.PveResources item, ClusterResourceType resourceType)
+        => item.GetAsync(resourceType switch
         {
             ClusterResourceType.Storage or ClusterResourceType.Node or ClusterResourceType.Vm => resourceType.ToString().ToLower(),
             ClusterResourceType.All => null,
@@ -30,18 +30,18 @@ public static class ModelsExtensions
     /// <summary>
     /// Read storage RRD statistics.
     /// </summary>
-    public static async Task<IEnumerable<NodeStorageRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveStorage.PveStorageItem.PveRrddata item,
-                                                                       RrdDataTimeFrame dataTimeFrame,
-                                                                       RrdDataConsolidation dataConsolidation)
-        => await item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
+    public static Task<IEnumerable<NodeStorageRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveStorage.PveStorageItem.PveRrddata item,
+                                                                 RrdDataTimeFrame dataTimeFrame,
+                                                                 RrdDataConsolidation dataConsolidation)
+        => item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
 
     /// <summary>
     /// Read node RRD statistics
     /// </summary>
-    public static async Task<IEnumerable<NodeRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveRrddata item,
-                                                                RrdDataTimeFrame dataTimeFrame,
-                                                                RrdDataConsolidation dataConsolidation)
-        => await item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
+    public static Task<IEnumerable<NodeRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveRrddata item,
+                                                          RrdDataTimeFrame dataTimeFrame,
+                                                          RrdDataConsolidation dataConsolidation)
+        => item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
 
     /// <summary>
     /// Read task log
@@ -50,8 +50,8 @@ public static class ModelsExtensions
     /// <param name="limit">The maximum amount of lines that should be printed.</param>
     /// <param name="start">The line number to start printing at.</param>
     public static async Task<IEnumerable<string>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveTasks.PveUpidItem.PveLog item,
-                                                       int? limit = null,
-                                                       int? start = null)
+                                                           int? limit = null,
+                                                           int? start = null)
         => (await item.ReadTaskLog(null, limit, start)).ToLogs();
 
     /// <summary>
@@ -131,8 +131,8 @@ public static class ModelsExtensions
     /// <param name="limit">The maximum amount of lines that should be printed.</param>
     /// <param name="start">The line number to start printing at.</param>
     public static async Task<IEnumerable<string>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveReplication.PveIdItem.PveLog item,
-                                                       int? limit = null,
-                                                       int? start = null)
+                                                           int? limit = null,
+                                                           int? start = null)
         => (await item.ReadJobLog(limit, start)).ToLogs();
 
 
@@ -143,7 +143,7 @@ public static class ModelsExtensions
                                                                                            int? vmId = null)
     {
         var ret = new List<NodeStorageContent>();
-        foreach (var item1 in await item.Storage.GetAsync(enabled: true, content: "backup"))
+        foreach (var item1 in await item.Storage.GetAsync(content: "backup", enabled: true))
         {
             if (item1.Active)
             {
@@ -157,18 +157,18 @@ public static class ModelsExtensions
     /// <summary>
     /// Read VM RRD statistics
     /// </summary>
-    public static async Task<IEnumerable<VmRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveQemu.PveVmidItem.PveRrddata item,
-                                                              RrdDataTimeFrame dataTimeFrame,
-                                                              RrdDataConsolidation dataConsolidation)
-        => await item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
+    public static Task<IEnumerable<VmRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveQemu.PveVmidItem.PveRrddata item,
+                                                        RrdDataTimeFrame dataTimeFrame,
+                                                        RrdDataConsolidation dataConsolidation)
+        => item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
 
     /// <summary>
     /// Read VM RRD statistics
     /// </summary>
-    public static async Task<IEnumerable<VmRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveLxc.PveVmidItem.PveRrddata item,
-                                                              RrdDataTimeFrame dataTimeFrame,
-                                                              RrdDataConsolidation dataConsolidation)
-        => await item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
+    public static Task<IEnumerable<VmRrdData>> GetAsync(this PveClient.PveNodes.PveNodeItem.PveLxc.PveVmidItem.PveRrddata item,
+                                                        RrdDataTimeFrame dataTimeFrame,
+                                                        RrdDataConsolidation dataConsolidation)
+        => item.GetAsync(dataTimeFrame.GetValue(), dataConsolidation.GetValue());
 
     #region Spice
     /// <summary>
@@ -186,8 +186,8 @@ public static class ModelsExtensions
     /// <param name="item"></param>
     /// <param name="proxy"></param>
     public static async Task<(bool Success, string ReasonPhrase, string Content)> GetSpiceFileVVAsync(this PveClient.PveNodes.PveNodeItem.PveLxc.PveVmidItem.PveSpiceproxy item,
-                                                                                                  string proxy)
-    => CreateSpiceFileVV(await item.Spiceproxy(proxy));
+                                                                                                      string proxy)
+        => CreateSpiceFileVV(await item.Spiceproxy(proxy));
 
     /// <summary>
     /// Get file for SPICE client using spice config
@@ -195,8 +195,8 @@ public static class ModelsExtensions
     /// <param name="item"></param>
     /// <param name="proxy"></param>
     public static async Task<(bool Success, string ReasonPhrase, string Content)> GetSpiceFileVVAsync(this PveClient.PveNodes.PveNodeItem.PveSpiceshell item,
-                                                                                                  string proxy)
-    => CreateSpiceFileVV(await item.Spiceshell(proxy: proxy));
+                                                                                                      string proxy)
+        => CreateSpiceFileVV(await item.Spiceshell(proxy: proxy));
 
     private static (bool Success, string ReasonPhrase, string Content) CreateSpiceFileVV(Result response)
     {

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ApiExplorerHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ApiExplorerHelper.cs
@@ -18,43 +18,33 @@ namespace Corsinvest.ProxmoxVE.Api.Extension.Utils;
 /// <summary>
 /// Api Explorer
 /// </summary>
-public static class ApiExplorerHelper
+public static partial class ApiExplorerHelper
 {
     /// <summary>
     /// Alias command.
     /// </summary>
-    public class AliasDef
+    public partial class AliasDef(string name, string description, string command, bool system)
     {
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        public AliasDef(string name, string description, string command, bool system)
-        {
-            Name = name;
-            Description = description;
-            Command = command;
-            System = system;
-        }
 
         /// <summary>
         /// Name
         /// </summary>
-        public string Name { get; }
+        public string Name { get; } = name;
 
         /// <summary>
         /// Description
         /// </summary>
-        public string Description { get; }
+        public string Description { get; } = description;
 
         /// <summary>
         /// Command
         /// </summary>
-        public string Command { get; }
+        public string Command { get; } = command;
 
         /// <summary>
         /// System
         /// </summary>
-        public bool System { get; }
+        public bool System { get; } = system;
 
         /// <summary>
         /// Check exists name or alias
@@ -69,7 +59,9 @@ public static class ApiExplorerHelper
         /// <summary>
         /// Check name is valid
         /// </summary>
-        public static bool IsValid(string name) => new Regex("^[a-zA-Z0-9,_-]*$").IsMatch(name);
+        public static bool IsValid(string name) => ValidNameRegex().IsMatch(name);
+        [GeneratedRegex("^[a-zA-Z0-9,_-]*$")]
+        private static partial Regex ValidNameRegex();
     }
 
     /// <summary>
@@ -243,7 +235,7 @@ public static class ApiExplorerHelper
     /// Get argument into command start "{" end "}"
     /// </summary>
     public static string[] GetArgumentTags(string command)
-        => [.. new Regex(@"{\s*(.+?)\s*}").Matches(command)
+        => [.. ArgumentTagRegex().Matches(command)
                                       .OfType<Match>()
                                       .Where(a => a.Success)
                                       .Select(a => a.Groups[1].Value)];
@@ -305,7 +297,7 @@ public static class ApiExplorerHelper
         var parameters = new Dictionary<string, object>();
         foreach (var item in items)
         {
-            var pos = item.IndexOf(":");
+            var pos = item.IndexOf(':');
             if (pos >= 0) { parameters.Add(item[..pos], item[(pos + 1)..]); }
         }
         return parameters;
@@ -398,9 +390,9 @@ public static class ApiExplorerHelper
         var rows = new List<object[]>();
         var print = false;
 
-        if (data is ExpandoObject)
+        if (data is ExpandoObject expandoObject)
         {
-            var dic = (IDictionary<string, object>)data;
+            var dic = (IDictionary<string, object>)expandoObject;
 
             columns.Add("key");
             columns.Add("value");
@@ -408,7 +400,7 @@ public static class ApiExplorerHelper
             keys ??= [.. dic.Select(a => a.Key)];
             print = true;
 
-            foreach (var key in keys.OrderBy(a => a))
+            foreach (var key in keys.Order())
             {
                 if (dic.TryGetValue(key, out var value))
                 {
@@ -419,8 +411,8 @@ public static class ApiExplorerHelper
         else if (data is IList list)
         {
             // Check if the list contains plain strings (e.g. /nodes/{node}/journal returns string[])
-            var firstItem = list.Count > 0 
-                                ? list[0] 
+            var firstItem = list.Count > 0
+                                ? list[0]
                                 : null;
             if (firstItem is string)
             {
@@ -434,7 +426,7 @@ public static class ApiExplorerHelper
                 {
                     var keysTmp = new List<string>();
                     foreach (IDictionary<string, object> item in data) { keysTmp.AddRange([.. item.Keys]); }
-                    keys = [.. keysTmp.Distinct().OrderBy(a => a)];
+                    keys = [.. keysTmp.Distinct().Order()];
                 }
 
                 columns.AddRange(keys);
@@ -517,7 +509,7 @@ public static class ApiExplorerHelper
                     //explicit text
                     partsType = JoinWord(param.TypeText.Split(' '), 18, string.Empty);
                 }
-                else if (param.EnumValues.Any())
+                else if (param.EnumValues.Length != 0)
                 {
                     //enums
                     partsType = JoinWord(param.EnumValues, 18, ",");
@@ -568,10 +560,10 @@ public static class ApiExplorerHelper
                 //only parameters no keys
                 var parameters = method.Parameters.Where(a => !classApi.Keys.Contains(a.Name));
 
-                var opts = string.Join(string.Empty, parameters.Where(a => !a.Optional)
-                                                               .Select(a => optionStyle
-                                                                            ? $" --{a.Name} <{a.Type}>"
-                                                                            : $" {a.Name}:<{a.Type}>"));
+                var opts = string.Concat(parameters.Where(a => !a.Optional)
+                                                   .Select(a => optionStyle
+                                                                ? $" --{a.Name} <{a.Type}>"
+                                                                : $" {a.Name}:<{a.Type}>"));
                 if (!string.IsNullOrWhiteSpace(opts)) { ret.Append(opts); }
 
                 //optional parameter
@@ -670,7 +662,7 @@ public static class ApiExplorerHelper
                             {
                                 var data = new List<object>();
                                 foreach (IDictionary<string, object> item in result.ToData()) { data.Add(item[key]); }
-                                foreach (var item in data.OrderBy(a => a)) { values.Add((attribute, item + string.Empty)); }
+                                foreach (var item in data.Order()) { values.Add((attribute, item + string.Empty)); }
                             }
                         }
                     }
@@ -697,4 +689,7 @@ public static class ApiExplorerHelper
                     : Environment.NewLine + error) +
                Environment.NewLine;
     }
+
+    [GeneratedRegex(@"{\s*(.+?)\s*}")]
+    private static partial Regex ArgumentTagRegex();
 }

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ClientHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ClientHelper.cs
@@ -244,29 +244,12 @@ namespace Corsinvest.ProxmoxVE.Api.Extension.Utils
             try
             {
                 using var tcpClient = new TcpClient();
-#if NET7_0_OR_GREATER
-                // .NET 7+ supports CancellationToken in ConnectAsync
                 using (var timeoutCts = new CancellationTokenSource(timeout))
                 using (var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token))
                 {
                     await tcpClient.ConnectAsync(endpoint.Host, endpoint.Port).ConfigureAwait(false);
                     return tcpClient.Connected;
                 }
-#else
-                // .NET Standard 2.0 and older versions don't support CancellationToken in ConnectAsync
-                var connectTask = tcpClient.ConnectAsync(endpoint.Host, endpoint.Port);
-                var completedTask = await Task.WhenAny(connectTask, Task.Delay(timeout, cancellationToken));
-
-                if (completedTask == connectTask)
-                {
-                    await connectTask; // Await to get any exceptions
-                    return tcpClient.Connected;
-                }
-                else
-                {
-                    return false; // Timeout
-                }
-#endif
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/MiscHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/MiscHelper.cs
@@ -13,7 +13,7 @@ namespace Corsinvest.ProxmoxVE.Api.Extension.Utils;
 /// <summary>
 /// BackupHelper
 /// </summary>
-public static class MiscHelper
+public static partial class MiscHelper
 {
     //public static DateTime ParseDateBackup(string value) => DateTime.ParseExact(value, "yyyy-MM-dd HH:mm:ss", null);
 
@@ -83,7 +83,7 @@ public static class MiscHelper
         if (parts.Count == 0) { throw new ArgumentException("Missing time specification"); }
 
         // Date spec (e.g. 2024-01-01) — not implemented
-        if (Regex.IsMatch(parts[0], @"^\d{4}-\d{2}-\d{2}$"))
+        if (DateSpecRegex().IsMatch(parts[0]))
         {
             throw new PveException("Date specification not implemented");
         }
@@ -110,13 +110,13 @@ public static class MiscHelper
         }
 
         return (string.Join(",", dowHash),
-                string.Join(",", matchAllHours ? Enumerable.Range(0, 24) : hoursHash.OrderBy(a => a)),
-                string.Join(",", matchAllMinutes ? Enumerable.Range(0, 60) : minutesHash.OrderBy(a => a)));
+                string.Join(",", matchAllHours ? Enumerable.Range(0, 24) : hoursHash.Order()),
+                string.Join(",", matchAllMinutes ? Enumerable.Range(0, 60) : minutesHash.Order()));
     }
 
     private static void ParseSingleTimeSpec(string item, int max, ref bool matchAll, List<int> hash)
     {
-        var match = Regex.Match(item, @"^((?:\*|[0-9]+))(?:\/([1-9][0-9]*))?$");
+        var match = TimeSpecRegex().Match(item);
         if (match.Success)
         {
             if (match.Groups.Count == 3 && !string.IsNullOrWhiteSpace(match.Groups[2].Value))
@@ -148,7 +148,7 @@ public static class MiscHelper
         }
         else
         {
-            match = Regex.Match(item, @"^([0-9]+)\.\.([1-9][0-9]*)$");
+            match = TimeRangeRegex().Match(item);
             if (!match.Success) { throw new ArgumentException($"Unable to parse calendar event '{item}"); }
 
             var start = int.Parse(match.Groups[1].Value);
@@ -159,6 +159,13 @@ public static class MiscHelper
             for (int i = start; i <= end; i++) { hash.Add(i); }
         }
     }
+
+    [GeneratedRegex(@"^\d{4}-\d{2}-\d{2}$")]
+    private static partial Regex DateSpecRegex();
+    [GeneratedRegex(@"^((?:\*|[0-9]+))(?:\/([1-9][0-9]*))?$")]
+    private static partial Regex TimeSpecRegex();
+    [GeneratedRegex(@"^([0-9]+)\.\.([1-9][0-9]*)$")]
+    private static partial Regex TimeRangeRegex();
 
     /// <summary>
     /// Opens a URL in the default system browser (cross-platform).

--- a/src/Corsinvest.ProxmoxVE.Api.Metadata/ClassApi.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Metadata/ClassApi.cs
@@ -11,7 +11,7 @@ namespace Corsinvest.ProxmoxVE.Api.Metadata;
 /// <summary>
 /// Class Api
 /// </summary>
-public class ClassApi
+public partial class ClassApi
 {
     /// <summary>
     /// Constructor
@@ -42,12 +42,12 @@ public class ClassApi
         Parent = parent;
         Resource = token["path"].ToString();
 
-        Resource = Regex.Replace(Resource, @"\{([^}]*)\}", match => "{" + match.Groups[1].Value.Replace('-', '_') + "}");
+        Resource = ResourcePlaceholderRegex().Replace(Resource, match => "{" + match.Groups[1].Value.Replace('-', '_') + "}");
 
         Keys.AddRange(parent.Keys);
         parent.SubClasses.Add(this);
 
-        IsIndexed = token["text"].ToString().StartsWith("{");
+        IsIndexed = token["text"].ToString().StartsWith('{');
         if (IsIndexed) { Keys.Add(IndexName); }
 
         if (token["info"] != null)
@@ -130,4 +130,7 @@ public class ClassApi
     /// Path resource
     /// </summary>
     public string Resource { get; }
+
+    [GeneratedRegex(@"\{([^}]*)\}")]
+    private static partial Regex ResourcePlaceholderRegex();
 }

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterCephStatus.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterCephStatus.cs
@@ -11,19 +11,19 @@ namespace Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 public class ClusterCephStatus : ModelBase
 {
     [JsonProperty("fsmap")]
-    public FsmapInt Fsmap { get; set; }
+    public FsmapInfo Fsmap { get; set; }
 
     [JsonProperty("servicemap")]
-    public ServicemapInt Servicemap { get; set; }
+    public ServicemapInfo Servicemap { get; set; }
 
     [JsonProperty("progress_events")]
-    public ProgressEventsInt ProgressEvents { get; set; }
+    public ProgressEventsInfo ProgressEvents { get; set; }
 
     [JsonProperty("quorum")]
     public IEnumerable<int> Quorum { get; set; } = [];
 
     [JsonProperty("osdmap")]
-    public OsdmapInt Osdmap { get; set; }
+    public OsdmapInfo Osdmap { get; set; }
 
     [JsonProperty("quorum_age")]
     public int QuorumAge { get; set; }
@@ -32,10 +32,10 @@ public class ClusterCephStatus : ModelBase
     public string Fsid { get; set; }
 
     [JsonProperty("monmap")]
-    public MonmapInt Monmap { get; set; }
+    public MonmapInfo Monmap { get; set; }
 
     [JsonProperty("pgmap")]
-    public PgmapInt Pgmap { get; set; }
+    public PgmapInfo Pgmap { get; set; }
 
     [JsonProperty("election_epoch")]
     public int ElectionEpoch { get; set; }
@@ -44,10 +44,10 @@ public class ClusterCephStatus : ModelBase
     public IEnumerable<string> QuorumNames { get; set; } = [];
 
     [JsonProperty("mgrmap")]
-    public MgrmapInt Mgrmap { get; set; }
+    public MgrmapInfo Mgrmap { get; set; }
 
     [JsonProperty("health")]
-    public HealthInt Health { get; set; }
+    public HealthInfo Health { get; set; }
 
     public class Active
     {
@@ -1131,7 +1131,7 @@ public class ClusterCephStatus : ModelBase
         public IEnumerable<string> Persistent { get; set; } = [];
     }
 
-    public class FsmapInt
+    public class FsmapInfo
     {
         [JsonProperty("epoch")]
         public int Epoch { get; set; }
@@ -1143,7 +1143,7 @@ public class ClusterCephStatus : ModelBase
         public int UpStandby { get; set; }
     }
 
-    public class HealthInt
+    public class HealthInfo
     {
         [JsonProperty("mutes")]
         public IEnumerable<object> Mutes { get; set; } = [];
@@ -1700,7 +1700,7 @@ public class ClusterCephStatus : ModelBase
         public int Flags { get; set; }
     }
 
-    public class MgrmapInt
+    public class MgrmapInfo
     {
         [JsonProperty("active_change")]
         public DateTime ActiveChange { get; set; }
@@ -2234,7 +2234,7 @@ public class ClusterCephStatus : ModelBase
         public string Addr { get; set; }
     }
 
-    public class MonmapInt
+    public class MonmapInfo
     {
         [JsonProperty("quorum")]
         public IEnumerable<int> Quorum { get; set; } = [];
@@ -2432,7 +2432,7 @@ public class ClusterCephStatus : ModelBase
         public string DefaultValue { get; set; }
     }
 
-    public class OsdmapInt
+    public class OsdmapInfo
     {
         [JsonProperty("num_up_osds")]
         public int NumUpOsds { get; set; }
@@ -2495,7 +2495,7 @@ public class ClusterCephStatus : ModelBase
         public string Desc { get; set; }
     }
 
-    public class PgmapInt
+    public class PgmapInfo
     {
         [JsonProperty("num_pools")]
         public int NumPools { get; set; }
@@ -2738,7 +2738,7 @@ public class ClusterCephStatus : ModelBase
         public IEnumerable<object> Tags { get; set; } = [];
     }
 
-    public class ProgressEventsInt;
+    public class ProgressEventsInfo;
 
     public class Proxy
     {
@@ -3448,7 +3448,7 @@ public class ClusterCephStatus : ModelBase
         public IEnumerable<object> Tags { get; set; } = [];
     }
 
-    public class ServicemapInt
+    public class ServicemapInfo
     {
         [JsonProperty("epoch")]
         public int Epoch { get; set; }

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterOptions.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterOptions.cs
@@ -34,7 +34,7 @@ public class ClusterOptions : ModelBase
     /// Migration
     /// </summary>
     [JsonProperty("migration")]
-    public MigrationInt Migration { get; set; }
+    public MigrationInfo Migration { get; set; }
 
     /// <summary>
     /// Mac Prefix
@@ -52,12 +52,12 @@ public class ClusterOptions : ModelBase
     /// Tag Style
     /// </summary>
     [JsonProperty("tag-style")]
-    public TagStyleInt TagStyle { get; set; }
+    public TagStyleInfo TagStyle { get; set; }
 
     /// <summary>
     /// Tag Style
     /// </summary>
-    public class TagStyleInt
+    public class TagStyleInfo
     {
         /// <summary>
         /// Color Map
@@ -69,7 +69,7 @@ public class ClusterOptions : ModelBase
     /// <summary>
     /// Migration
     /// </summary>
-    public class MigrationInt
+    public class MigrationInfo
     {
         /// <summary>
         /// Network

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmBaseStatusCurrent.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmBaseStatusCurrent.cs
@@ -171,12 +171,12 @@ public class VmBaseStatusCurrent : ModelBase, IVmBase, INetIO, IDisk, IMemory, I
     /// HA manager service status.
     /// </summary>
     [JsonProperty("ha")]
-    public HaInt Ha { get; set; }
+    public HaInfo Ha { get; set; }
 
     /// <summary>
     /// Ha
     /// </summary>
-    public class HaInt
+    public class HaInfo
     {
         /// <summary>
         /// Managed

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
@@ -13,7 +13,7 @@ namespace Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 /// <summary>
 /// Vm Config
 /// </summary>
-public class VmConfig : ModelBase
+public partial class VmConfig : ModelBase
 {
     /// <summary>
     /// Virtual processor architecture. Defaults to the host.
@@ -140,99 +140,101 @@ public class VmConfig : ModelBase
         {
             if (key.StartsWith("net"))
             {
-                var network = new VmNetwork();
-                network.Id = key;
+                var network = new VmNetwork
+                {
+                    Id = key
+                };
 
                 foreach (var item in (ExtensionData[key] + string.Empty).Split(','))
                 {
                     Match match;
                     if (this is VmConfigQemu)
                     {
-                        if ((match = Regex.Match(item, "^(ne2k_pci|e1000e?|e1000-82540em|e1000-82544gc|e1000-82545em|vmxnet3|rtl8139|pcnet|virtio|ne2k_isa|i82551|i82557b|i82559er)(=([0-9a-f]{2}(:[0-9a-f]{2}){5}))?$", RegexOptions.IgnoreCase)).Success)
+                        if ((match = NicModelRegex().Match(item)).Success)
                         {
                             network.Model = match.Groups[1].Value.ToLower();
                             if (match.Groups[3].Success) { network.MacAddress = match.Groups[3].Value; }
                         }
-                        else if ((match = Regex.Match(item, @"^bridge=(\S+)$")).Success)
+                        else if ((match = BridgeRegex().Match(item)).Success)
                         {
                             network.Bridge = match.Groups[1].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^rate=(\d+(\.\d+)?|\.\d+)$")).Success)
+                        else if ((match = RateRegex().Match(item)).Success)
                         {
                             network.Rate = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
                         }
-                        else if ((match = Regex.Match(item, @"^tag=(\d+(\.\d+)?)$")).Success)
+                        else if ((match = TagRegex().Match(item)).Success)
                         {
                             network.Tag = int.Parse(match.Groups[1].Value);
                         }
-                        else if ((match = Regex.Match(item, @"^firewall=(\d+)$")).Success)
+                        else if ((match = FirewallRegex().Match(item)).Success)
                         {
                             network.Firewall = match.Groups[1].Value == "1";
                         }
-                        else if ((match = Regex.Match(item, @"^link_down=(\d+)$")).Success)
+                        else if ((match = LinkDownRegex().Match(item)).Success)
                         {
                             network.Disconnect = match.Groups[1].Value == "1";
                         }
-                        else if ((match = Regex.Match(item, @"^queues=(\d+)$")).Success)
+                        else if ((match = QueuesRegex().Match(item)).Success)
                         {
                             network.Queues = int.Parse(match.Groups[1].Value);
                         }
-                        else if ((match = Regex.Match(item, @"^trunks=(\d+(?:-\d+)?(?:;\d+(?:-\d+)?)*)$")).Success)
+                        else if ((match = TrunksRegex().Match(item)).Success)
                         {
                             network.Trunks = match.Groups[1].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^mtu=(\d+)$")).Success)
+                        else if ((match = MtuRegex().Match(item)).Success)
                         {
                             network.Mtu = int.Parse(match.Groups[1].Value);
                         }
                     }
                     else if (this is VmConfigLxc)
                     {
-                        if ((match = Regex.Match(item, @"^(bridge)=(\S+)$")).Success)
+                        if ((match = BridgeRegex().Match(item)).Success)
                         {
-                            network.Bridge = match.Groups[2].Value;
+                            network.Bridge = match.Groups[1].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(gw)=(\S+)$")).Success)
+                        else if ((match = GwRegex().Match(item)).Success)
                         {
                             network.Gateway = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(gw6)=(\S+)$")).Success)
+                        else if ((match = Gw6Regex().Match(item)).Success)
                         {
                             network.Gateway6 = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(hwaddr)=(\S+)$")).Success)
+                        else if ((match = HwAddrRegex().Match(item)).Success)
                         {
                             network.MacAddress = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(rate)=(\S+)$")).Success)
+                        else if ((match = RateRegex().Match(item)).Success)
                         {
-                            network.Rate = double.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+                            network.Rate = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
                         }
-                        else if ((match = Regex.Match(item, @"^(tag)=(\S+)$")).Success)
+                        else if ((match = TagRegex().Match(item)).Success)
                         {
-                            network.Tag = int.Parse(match.Groups[2].Value);
+                            network.Tag = int.Parse(match.Groups[1].Value);
                         }
-                        else if ((match = Regex.Match(item, @"^(mtu)=(\S+)$")).Success)
+                        else if ((match = MtuRegex().Match(item)).Success)
                         {
-                            network.Mtu = int.Parse(match.Groups[2].Value);
+                            network.Mtu = int.Parse(match.Groups[1].Value);
                         }
-                        else if ((match = Regex.Match(item, @"^(name)=(\S+)$")).Success)
+                        else if ((match = NameRegex().Match(item)).Success)
                         {
                             network.Name = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(ip)=(\S+)$")).Success)
+                        else if ((match = IpRegex().Match(item)).Success)
                         {
                             network.IpAddress = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^(ip6)=(\S+)$")).Success)
+                        else if ((match = Ip6Regex().Match(item)).Success)
                         {
                             network.IpAddress6 = match.Groups[2].Value;
                         }
-                        else if ((match = Regex.Match(item, @"^firewall=(\d+)$")).Success)
+                        else if ((match = FirewallRegex().Match(item)).Success)
                         {
                             network.Firewall = match.Groups[1].Value == "1";
                         }
-                        else if ((match = Regex.Match(item, @"^link_down=(\d+)$")).Success)
+                        else if ((match = LinkDownRegex().Match(item)).Success)
                         {
                             network.LinkDown = match.Groups[1].Value == "1";
                         }
@@ -257,8 +259,8 @@ public class VmConfig : ModelBase
             if (key == "rootfs"
                 || key.StartsWith("unused")
                 //bus match
-                || (Regex.IsMatch(key, @"(efidisk|tpmstate|virtio|ide|scsi|sata|mp)\d+")
-                    && !Regex.IsMatch(def, "media=cdrom")))
+                || (DiskKeyRegex().IsMatch(key)
+                    && !CdromMediaRegex().IsMatch(def)))
             {
                 var infos = def.Split(',');
                 var storage = string.Empty;
@@ -267,7 +269,7 @@ public class VmConfig : ModelBase
                 var device = string.Empty;
                 var mountSourcePath = string.Empty;
 
-                if (infos[0].Contains(":"))
+                if (infos[0].Contains(':'))
                 {
                     var data = infos[0].Split(':');
                     storage = data[0];
@@ -318,4 +320,39 @@ public class VmConfig : ModelBase
         }
         Disks = disks;
     }
+
+    [GeneratedRegex(@"(efidisk|tpmstate|virtio|ide|scsi|sata|mp)\d+")]
+    private static partial Regex DiskKeyRegex();
+    [GeneratedRegex("media=cdrom")]
+    private static partial Regex CdromMediaRegex();
+    [GeneratedRegex("^(ne2k_pci|e1000e?|e1000-82540em|e1000-82544gc|e1000-82545em|vmxnet3|rtl8139|pcnet|virtio|ne2k_isa|i82551|i82557b|i82559er)(=([0-9a-f]{2}(:[0-9a-f]{2}){5}))?$", RegexOptions.IgnoreCase)]
+    private static partial Regex NicModelRegex();
+    [GeneratedRegex(@"^bridge=(\S+)$")]
+    private static partial Regex BridgeRegex();
+    [GeneratedRegex(@"^rate=(\d+(\.\d+)?|\.\d+)$")]
+    private static partial Regex RateRegex();
+    [GeneratedRegex(@"^tag=(\d+(\.\d+)?)$")]
+    private static partial Regex TagRegex();
+    [GeneratedRegex(@"^firewall=(\d+)$")]
+    private static partial Regex FirewallRegex();
+    [GeneratedRegex(@"^link_down=(\d+)$")]
+    private static partial Regex LinkDownRegex();
+    [GeneratedRegex(@"^queues=(\d+)$")]
+    private static partial Regex QueuesRegex();
+    [GeneratedRegex(@"^trunks=(\d+(?:-\d+)?(?:;\d+(?:-\d+)?)*)$")]
+    private static partial Regex TrunksRegex();
+    [GeneratedRegex(@"^mtu=(\d+)$")]
+    private static partial Regex MtuRegex();
+    [GeneratedRegex(@"^(gw)=(\S+)$")]
+    private static partial Regex GwRegex();
+    [GeneratedRegex(@"^(gw6)=(\S+)$")]
+    private static partial Regex Gw6Regex();
+    [GeneratedRegex(@"^(hwaddr)=(\S+)$")]
+    private static partial Regex HwAddrRegex();
+    [GeneratedRegex(@"^(name)=(\S+)$")]
+    private static partial Regex NameRegex();
+    [GeneratedRegex(@"^(ip)=(\S+)$")]
+    private static partial Regex IpRegex();
+    [GeneratedRegex(@"^(ip6)=(\S+)$")]
+    private static partial Regex Ip6Regex();
 }

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfigQemu.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfigQemu.cs
@@ -25,7 +25,8 @@ public class VmConfigQemu : VmConfig
     public string Cpu { get; set; }
 
     /// <summary>
-    /// Keyboard layout for VNC server. This option is generally not required and is often better handled from within the guest OS.
+    /// Keyboard layout for VNC server.
+    /// This option is generally not required and is often better handled from within the guest OS.
     /// </summary>
     [JsonProperty("keyboard")]
     public string Keyboard { get; set; }
@@ -58,7 +59,8 @@ public class VmConfigQemu : VmConfig
     /// Agent enabled.
     /// </summary>
     public bool AgentEnabled
-        => !string.IsNullOrWhiteSpace(Agent) && Agent.Split(',').Select(a => a.Trim()).Any(a => a == "1");
+        => !string.IsNullOrWhiteSpace(Agent)
+            && Agent.Split(',').Select(a => a.Trim()).Any(a => a == "1");
 
     /// <summary>
     /// Enable booting from specified disk. Deprecated: Use 'boot: order=foo;bar' instead.
@@ -94,7 +96,7 @@ public class VmConfigQemu : VmConfig
     /// Amount of target RAM for the VM in MiB. Using zero disables the ballon driver.
     /// </summary>
     [JsonProperty("balloon")]
-    public int Balloon { get; set; }
+    public int? Balloon { get; set; }
 
     /// <summary>
     /// cloud-init: Sets DNS search domains for a container. Create will automatically use the setting from the host if neither searchdomain nor nameserver are set.
@@ -295,7 +297,7 @@ public class VmConfigQemu : VmConfig
     public string Ivshmem { get; set; }
 
     /// <summary>
-    /// Use together with hugepages. If enabled, hugepages will not not be deleted after VM shutdown and can be used for subsequent starts.
+    /// Use together with hugepages. If enabled, hugepages will not be deleted after VM shutdown and can be used for subsequent starts.
     /// </summary>
     [JsonProperty("keephugepages")]
     public bool Keephugepages { get; set; }

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetFsInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetFsInfo.cs
@@ -18,12 +18,12 @@ public class VmQemuAgentGetFsInfo : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public IEnumerable<ResultInt> Result { get; set; } = [];
+    public IEnumerable<ResultInfo> Result { get; set; } = [];
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Error

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetHostName.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetHostName.cs
@@ -16,12 +16,12 @@ public class VmQemuAgentGetHostName : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public ResultInt Result { get; set; }
+    public ResultInfo Result { get; set; }
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Hostname

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetTimeZone.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetTimeZone.cs
@@ -16,12 +16,12 @@ public class VmQemuAgentGetTimeZone : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public ResultInt Result { get; set; }
+    public ResultInfo Result { get; set; }
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Offset

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetVCpus.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentGetVCpus.cs
@@ -16,12 +16,12 @@ public class VmQemuAgentGetVCpus : ModelBase
     /// Data
     /// </summary>
     [JsonProperty("result")]
-    public IEnumerable<ResultInt> Result { get; set; } = [];
+    public IEnumerable<ResultInfo> Result { get; set; } = [];
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Can Offline

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentInfo.cs
@@ -16,12 +16,12 @@ public class VmQemuAgentInfo : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public ResultInt Result { get; set; }
+    public ResultInfo Result { get; set; }
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Supported Commands

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentNetworkGetInterfaces.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentNetworkGetInterfaces.cs
@@ -16,7 +16,7 @@ public class VmQemuAgentNetworkGetInterfaces : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public IEnumerable<ResultInt> Result { get; set; } = [];
+    public IEnumerable<ResultInfo> Result { get; set; } = [];
 
     /// <summary>
     /// IpAddress
@@ -99,7 +99,7 @@ public class VmQemuAgentNetworkGetInterfaces : ModelBase
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// IpAddresses

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentOsInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuAgentOsInfo.cs
@@ -16,12 +16,12 @@ public class VmQemuAgentOsInfo : ModelBase
     /// Result
     /// </summary>
     [JsonProperty("result")]
-    public ResultInt Result { get; set; }
+    public ResultInfo Result { get; set; }
 
     /// <summary>
     /// Result
     /// </summary>
-    public class ResultInt
+    public class ResultInfo
     {
         /// <summary>
         /// Pretty Name

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuStatusCurrent.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmQemuStatusCurrent.cs
@@ -62,13 +62,13 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// Nigs
     /// </summary>
     [JsonProperty("nics")]
-    public IDictionary<string, NicsInt> Nics { get; set; }
+    public IDictionary<string, NicsInfo> Nics { get; set; }
 
     /// <summary>
     /// Block Stat
     /// </summary>
     [JsonProperty("blockstat")]
-    public IDictionary<string, BlockstatInt> BlockStat { get; set; }
+    public IDictionary<string, BlockstatInfo> BlockStat { get; set; }
 
     /// <summary>
     /// Balloon
@@ -80,13 +80,13 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// Balloon info
     /// </summary>
     [JsonProperty("ballooninfo")]
-    public BalloonInfoInt Ballooninfo { get; set; }
+    public BalloonInfoData Ballooninfo { get; set; }
 
     /// <summary>
     /// Proxmox Support
     /// </summary>
     [JsonProperty("proxmox-support")]
-    public ProxmoxSupportInt ProxmoxSupport { get; set; }
+    public ProxmoxSupportInfo ProxmoxSupport { get; set; }
 
     [OnDeserialized]
     internal void OnSerializedMethod(StreamingContext context) => OnSerializedMethodBase();
@@ -94,7 +94,7 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// <summary>
     /// Nics
     /// </summary>
-    public class NicsInt : INetIO
+    public class NicsInfo : INetIO
     {
         /// <summary>
         /// The amount of traffic in bytes that was sent to the guest over the network since it was started.
@@ -114,7 +114,7 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// <summary>
     /// Block stat
     /// </summary>
-    public class BlockstatInt
+    public class BlockstatInfo
     {
         /// <summary>
         /// Unmap Bytes
@@ -276,7 +276,7 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// <summary>
     /// Balloon info
     /// </summary>
-    public class BalloonInfoInt
+    public class BalloonInfoData
     {
         /// <summary>
         /// Actual
@@ -300,7 +300,7 @@ public class VmQemuStatusCurrent : VmBaseStatusCurrent
     /// <summary>
     /// Proxmox Support
     /// </summary>
-    public class ProxmoxSupportInt
+    public class ProxmoxSupportInfo
     {
         /// <summary>
         /// Pbs Dirty Bitmap Save Vm

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/TableGenerator.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/TableGenerator.cs
@@ -13,8 +13,10 @@ namespace Corsinvest.ProxmoxVE.Api.Shared.Utils;
 /// <summary>
 /// Table generator
 /// </summary>
-public static class TableGenerator
+public static partial class TableGenerator
 {
+    [GeneratedRegex("[^|]")]
+    private static partial Regex NonPipeCharRegex();
     /// <summary>
     /// Export to
     /// </summary>
@@ -117,7 +119,7 @@ public static class TableGenerator
         var columnHeaders = string.Format(format, [.. columns]);
 
         ret.AppendLine(columnHeaders);
-        ret.AppendLine(Regex.Replace(columnHeaders, "[^|]", "-"));
+        ret.AppendLine(NonPipeCharRegex().Replace(columnHeaders, "-"));
         rows.Select(row => string.Format(format, [.. row])).ToList().ForEach(row => ret.AppendLine(row));
         return ret.ToString();
     }
@@ -132,7 +134,7 @@ public static class TableGenerator
         var ret = new StringBuilder();
         var format = CreateStringFormat(columns, rows);
         var columnHeaders = string.Format(format, [.. columns]);
-        var dividerPlus = Regex.Replace(columnHeaders, "[^|]", "-").Replace("|", "+");
+        var dividerPlus = NonPipeCharRegex().Replace(columnHeaders, "-").Replace("|", "+");
 
         ret.AppendLine(dividerPlus);
         ret.AppendLine(columnHeaders);

--- a/src/Corsinvest.ProxmoxVE.Api.Test/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Test/Program.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Logging;
 System.Console.WriteLine("pippo");
 
 
-var app = ConsoleHelper.CreateApp("Test", "Automatic snapshot VM/CT with retention");
+var app = ConsoleHelper.CreateApp("Automatic snapshot VM/CT with retention");
 var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
-await app.ExecuteAppAsync(args, loggerFactory.CreateLogger(typeof(Program)));
+await app.ExecuteAppAsync(args, loggerFactory.CreateLogger<Program>());
 
 
 

--- a/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
@@ -68,7 +68,7 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
     /// <summary>
     /// Gets the base URL for the Proxmox API.
     /// </summary>
-    public string GetApiUrl() => $"{BaseAddress}/api2/{Enum.GetName(typeof(ResponseType), ResponseType)?.ToLower()}";
+    public string GetApiUrl() => $"{BaseAddress}/api2/{Enum.GetName<ResponseType>(ResponseType)?.ToLower()}";
 
     /// <summary>
     /// BaseAddress
@@ -242,32 +242,32 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
     /// </summary>
     /// <param name="resource">Url request</param>
     /// <param name="parameters">Additional parameters</param>
-    public async Task<Result> GetAsync(string resource, IDictionary<string, object> parameters = null)
-    => await ExecuteRequestAsync(resource, MethodType.Get, parameters);
+    public Task<Result> GetAsync(string resource, IDictionary<string, object> parameters = null)
+        => ExecuteRequestAsync(resource, MethodType.Get, parameters);
 
     /// <summary>
     /// Execute method POST
     /// </summary>
     /// <param name="resource">Url request</param>
     /// <param name="parameters">Additional parameters</param>
-    public async Task<Result> CreateAsync(string resource, IDictionary<string, object> parameters = null)
-    => await ExecuteRequestAsync(resource, MethodType.Create, parameters);
+    public Task<Result> CreateAsync(string resource, IDictionary<string, object> parameters = null)
+        => ExecuteRequestAsync(resource, MethodType.Create, parameters);
 
     /// <summary>
     /// Execute method PUT
     /// </summary>
     /// <param name="resource">Url request</param>
     /// <param name="parameters">Additional parameters</param>
-    public async Task<Result> SetAsync(string resource, IDictionary<string, object> parameters = null)
-    => await ExecuteRequestAsync(resource, MethodType.Set, parameters);
+    public Task<Result> SetAsync(string resource, IDictionary<string, object> parameters = null)
+        => ExecuteRequestAsync(resource, MethodType.Set, parameters);
 
     /// <summary>
     /// Execute method DELETE
     /// </summary>
     /// <param name="resource">Url request</param>
     /// <param name="parameters">Additional parameters</param>
-    public async Task<Result> DeleteAsync(string resource, IDictionary<string, object> parameters = null)
-    => await ExecuteRequestAsync(resource, MethodType.Delete, parameters);
+    public Task<Result> DeleteAsync(string resource, IDictionary<string, object> parameters = null)
+        => ExecuteRequestAsync(resource, MethodType.Delete, parameters);
 
     /// <summary>
     /// Get http client
@@ -366,10 +366,12 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
 
         HttpResponseMessage response = null!;
         dynamic result = null;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
 
         try
         {
             response = await GetHttpClient().SendAsync(request, cts.Token);
+            sw.Stop();
 
             switch (ResponseType)
             {
@@ -377,13 +379,13 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
                     result = JsonConvert.DeserializeObject<ExpandoObject>(await response.Content.ReadAsStringAsync());
                     if (_logger.IsEnabled(LogLevel.Trace))
                     {
-                        _logger.LogTrace(JsonConvert.SerializeObject(result, Formatting.Indented) as string);
+                        _logger.LogTrace("{Json}", JsonConvert.SerializeObject(result, Formatting.Indented) as string);
                     }
                     break;
 
                 case ResponseType.Png:
                     result = "data:image/png;base64," + Convert.ToBase64String(await response.Content.ReadAsByteArrayAsync());
-                    if (_logger.IsEnabled(LogLevel.Trace)) { _logger.LogTrace(result as string); }
+                    if (_logger.IsEnabled(LogLevel.Trace)) { _logger.LogTrace("{Data}", (string)result); }
                     break;
 
                 case ResponseType.Response: result = response; break;
@@ -393,7 +395,8 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
         }
         catch (TaskCanceledException ex) when (!cts.Token.IsCancellationRequested)
         {
-            _logger.LogError(ex, ex.Message);
+            sw.Stop();
+            _logger.LogError(ex, "{Message}", ex.Message);
 
             response = new(HttpStatusCode.RequestTimeout)
             {
@@ -402,7 +405,8 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, ex.Message);
+            sw.Stop();
+            _logger.LogError(ex, "{Message}", ex.Message);
 
             response = new(HttpStatusCode.InternalServerError)
             {
@@ -412,10 +416,11 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug("StatusCode: {StatusCode} ReasonPhrase: {ReasonPhrase} IsSuccessStatusCode: {IsSuccessStatusCode}",
+            _logger.LogDebug("StatusCode: {StatusCode} ReasonPhrase: {ReasonPhrase} IsSuccessStatusCode: {IsSuccessStatusCode} Duration: {ElapsedMilliseconds}ms",
                              response.StatusCode,
                              response.ReasonPhrase,
-                             response.IsSuccessStatusCode);
+                             response.IsSuccessStatusCode,
+                             sw.ElapsedMilliseconds);
         }
 
         result ??= new ExpandoObject();
@@ -457,7 +462,7 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
     /// Waits for a background task to finish.
     /// </summary>
     public async Task<bool> WaitForTaskToFinishAsync(Result result, int wait = 500, long timeout = 10000)
-        => !(result != null && !result.ResponseInError && timeout > 0) ||
+        => !(result?.ResponseInError is false && timeout > 0) ||
                 await WaitForTaskToFinishAsync(result.ToData(), wait, timeout);
 
     /// <summary>
@@ -499,6 +504,6 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
     /// <summary>
     /// Reads the current status of a task.
     /// </summary>
-    private async Task<Result> ReadTaskStatusAsync(string task)
-        => await GetAsync($"/nodes/{GetNodeFromTask(task)}/tasks/{task}/status");
+    private Task<Result> ReadTaskStatusAsync(string task)
+        => GetAsync($"/nodes/{GetNodeFromTask(task)}/tasks/{task}/status");
 }

--- a/src/Corsinvest.ProxmoxVE.Api/PveWebTermClient.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/PveWebTermClient.cs
@@ -15,7 +15,7 @@ namespace Corsinvest.ProxmoxVE.Api;
 /// <summary>
 /// PVE Web Terminal Client
 /// </summary>
-public class PveWebTermClient(PveClient client, string node) : IAsyncDisposable
+public partial class PveWebTermClient(PveClient client, string node) : IAsyncDisposable
 {
     private readonly ClientWebSocket _ws = new();
     private readonly CancellationTokenSource _cts = new();
@@ -26,8 +26,14 @@ public class PveWebTermClient(PveClient client, string node) : IAsyncDisposable
     private readonly SemaphoreSlim _bufferLock = new(1, 1);
     private ILogger<PveWebTermClient> _logger;
 
-    private static readonly Regex _shellPromptRegex = new(@"root@\w+:~#\s*", RegexOptions.Compiled);
-    private static readonly Regex _bracketedPasteEndRegex = new(@"\x1b\[\?2004h", RegexOptions.Compiled);
+    [GeneratedRegex(@"root@\w+:~#\s*")]
+    private static partial Regex ShellPromptRegex();
+    [GeneratedRegex(@"\x1b\[\?2004h")]
+    private static partial Regex BracketedPasteEndRegex();
+    [GeneratedRegex(@"\x1B\[\?2004l\r(.*?)\r?\x1B\[\?2004h", RegexOptions.Singleline)]
+    private static partial Regex BracketedPasteContentRegex();
+    [GeneratedRegex("([a-fA-F0-9]{64})")]
+    private static partial Regex Sha256HashRegex();
 
     private ILogger<PveWebTermClient> Logger => _logger ??= client.LoggerFactory.CreateLogger<PveWebTermClient>();
 
@@ -68,11 +74,7 @@ public class PveWebTermClient(PveClient client, string node) : IAsyncDisposable
 
         if (!client.ValidateCertificate)
         {
-#if NET7_0_OR_GREATER
             _ws.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
-#else
-            ServicePointManager.ServerCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
-#endif
         }
 
         await _ws.ConnectAsync(uri, _cts.Token);
@@ -194,8 +196,8 @@ public class PveWebTermClient(PveClient client, string node) : IAsyncDisposable
         while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMs)
         {
             if (_loginConfirmed
-                && (_shellPromptRegex.IsMatch(await GetOutputAsync())
-                    || _bracketedPasteEndRegex.IsMatch(await GetOutputAsync())))
+                && (ShellPromptRegex().IsMatch(await GetOutputAsync())
+                    || BracketedPasteEndRegex().IsMatch(await GetOutputAsync())))
             {
                 return true;
             }
@@ -309,7 +311,7 @@ echo '{endMarker}'
     }
 
     private async Task<Match> ExtractBracketedPasteContentAsync()
-        => Regex.Match(await GetOutputAsync(), @"\x1B\[\?2004l\r(.*?)\r?\x1B\[\?2004h", RegexOptions.Singleline);
+        => BracketedPasteContentRegex().Match(await GetOutputAsync());
 
     /// <summary>
     /// Download file from remote path
@@ -336,7 +338,7 @@ echo '{endMarker}'
             var match = await ExtractBracketedPasteContentAsync();
             if (!match.Success) { return (false, "SHA256 command output not found."); }
 
-            match = Regex.Match(match.Groups[1].Value, "([a-fA-F0-9]{64})");
+            match = Sha256HashRegex().Match(match.Groups[1].Value);
             if (!match.Success) { return (false, "Could not retrieve remote SHA256 hash."); }
             var remoteHash = match.Groups[1].Value.ToLowerInvariant();
 
@@ -369,11 +371,7 @@ echo '{endMarker}'
 
                 if (chunkBytes.Length == 0) { break; }
                 sha256.TransformBlock(chunkBytes, 0, chunkBytes.Length, null, 0);
-#if NET7_0_OR_GREATER
                 await stream.WriteAsync(chunkBytes);
-#else
-                await stream.WriteAsync(chunkBytes, 0, chunkBytes.Length);
-#endif
             }
 
             sha256.TransformFinalBlock([], 0, 0);
@@ -402,5 +400,6 @@ echo '{endMarker}'
     {
         await DisconnectAsync();
         _cts.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Api/ResultExtension.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/ResultExtension.cs
@@ -41,7 +41,7 @@ public static class ResultExtension
     /// <summary>
     /// Check result in error.
     /// </summary>
-    public static bool InError(this Result result) => result != null && result.ResponseInError;
+    public static bool InError(this Result result) => result?.ResponseInError is true;
 
     /// <summary>
     /// Convert result to model


### PR DESCRIPTION
## Summary

- Add `--log-level` option (Trace/Debug/Warning/Error/Critical) to all console apps via `CreateApp()`; `--debug` now correctly maps to `LogLevel.Debug` instead of `LogLevel.Trace`
- Add HTTP request duration logging (`Stopwatch`) shown at `Debug` level alongside StatusCode
- Fix `LogTrace`/`LogError` structured logging template warnings
- Convert all inline `new Regex(...)` to `[GeneratedRegex]` with meaningful names (`ValidNameRegex`, `ArgumentTagRegex`, `DiskKeyRegex`, `NicModelRegex`, `ShellPromptRegex`, etc.)
- Rename nested classes with `*Int` suffix to `*Info` (`HaInt`→`HaInfo`, `ResultInt`→`ResultInfo`, `NicsInt`→`NicsInfo`, etc.)
- Remove `#if NET7_0_OR_GREATER` and `#if !NETSTANDARD` conditional compilation blocks (min target is now net8.0)
- Remove unnecessary `async/await` where direct `Task` return suffices
- Add `GC.SuppressFinalize(this)` in `PveWebTermClient.DisposeAsync`
- Fix `VmConfigQemu.Balloon` from `int` to `int?`
- Update `VmIdsOrNamesOption` description to match all `GetVmsAsync` capabilities (`all`, `all-node`)
- `TableGenerator`: use `ElementAt`, `Max(selector)`, `NonPipeCharRegex`
- Bump version to 9.1.13

## Test plan
- [ ] Build solution targeting net8/net9/net10
- [ ] Verify `--debug` shows Method/URL but not JSON body
- [ ] Verify `--log-level Trace` shows JSON body
- [ ] Verify duration appears in debug log output