### PR TITLE
feat: add RemoteViewerHelper, VncWebSocketBridge, bump v9.1.14

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.13</Version>
+        <Version>9.1.14</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/RemoteViewerHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/RemoteViewerHelper.cs
@@ -1,0 +1,236 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+#nullable enable
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Web;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
+using Corsinvest.ProxmoxVE.Api.Shared.Utils;
+
+namespace Corsinvest.ProxmoxVE.Api.Extension.Utils;
+
+/// <summary>
+/// Helper for launching SPICE and VNC remote-viewer sessions against Proxmox VE.
+/// </summary>
+public static partial class RemoteViewerHelper
+{
+    [GeneratedRegex(@"^(http|https|)://.*$")]
+    private static partial Regex HttpRegex();
+
+    /// <summary>
+    /// Prepares a SPICE .vv file for the given VM/CT and returns its path.
+    /// If <paramref name="proxy"/> is null or whitespace, defaults to <c>client.Host</c>.
+    /// </summary>
+    public static async Task<(string? Error, string? FileName)>
+        PrepareSpiceAsync(PveClient client,
+                          string node,
+                          VmType vmType,
+                          long vmId,
+                          string? proxy = null,
+                          TextWriter? output = null)
+    {
+        if (string.IsNullOrWhiteSpace(proxy)) { proxy = client.Host; }
+
+        var (success, reasonPhrase, content) = vmType switch
+        {
+            VmType.Qemu => await client.Nodes[node].Qemu[vmId].Spiceproxy.GetSpiceFileVVAsync(proxy),
+            VmType.Lxc => await client.Nodes[node].Lxc[vmId].Spiceproxy.GetSpiceFileVVAsync(proxy),
+            _ => throw new InvalidEnumArgumentException(),
+        };
+
+        if (!success) { return (reasonPhrase, null); }
+
+        content = await ReplaceProxyInContentAsync(content, proxy, output);
+
+        var fileName = Path.GetTempFileName().Replace(".tmp", ".vv");
+        await File.WriteAllTextAsync(fileName, content);
+        return (null, fileName);
+    }
+
+    /// <summary>
+    /// Opens a VNC WebSocket tunnel and prepares a .vv file for the given VM/CT.
+    /// The caller must dispose the returned <see cref="VncWebSocketBridge"/> after the viewer exits.
+    /// </summary>
+    public static async Task<(string? Error, string? FileName, VncWebSocketBridge? Bridge)>
+        PrepareVncAsync(PveClient client, string node, VmType vmType, long vmId, TextWriter? output = null)
+    {
+        var vncResult = vmType switch
+        {
+            VmType.Qemu => await client.Nodes[node].Qemu[vmId].Vncproxy.Vncproxy(websocket: true),
+            VmType.Lxc => await client.Nodes[node].Lxc[vmId].Vncproxy.Vncproxy(websocket: true),
+            _ => throw new InvalidEnumArgumentException(),
+        };
+
+        if (!vncResult.IsSuccessStatusCode) { return (vncResult.ReasonPhrase, null, null); }
+
+        var ticket = (string)vncResult.Response.data.ticket;
+        var port = Convert.ToInt32(vncResult.Response.data.port);
+
+        var vmTypeStr = vmType switch
+        {
+            VmType.Qemu => "qemu",
+            VmType.Lxc => "lxc",
+            _ => throw new InvalidEnumArgumentException(),
+        };
+
+        var wsUrl = NoVncHelper.GetWebsocketUrl(client.Host,
+                                                client.Port,
+                                                node,
+                                                vmTypeStr,
+                                                vmId,
+                                                port,
+                                                HttpUtility.UrlEncode(ticket));
+
+        if (output != null) { await output.WriteLineAsync($"VNC WebSocket URL: {wsUrl}"); }
+
+        var vmTypeStrvv = vmType switch
+        {
+            VmType.Qemu => "VM",
+            VmType.Lxc => "CT",
+            _ => throw new InvalidEnumArgumentException(),
+        };
+
+        return await CreateVncWebSocketBridgeAsync(client, wsUrl, ticket, $"VNC: {vmTypeStrvv} {vmId}", output);
+    }
+
+    /// <summary>
+    /// Prepares a SPICE .vv file for the given node shell and returns its path.
+    /// </summary>
+    public static async Task<(string? Error, string? FileName)>
+        PrepareSpiceAsync(PveClient client, string node, string? proxy = null, TextWriter? output = null)
+    {
+        if (string.IsNullOrWhiteSpace(proxy)) { proxy = client.Host; }
+
+        var (success, reasonPhrase, content) = await client.Nodes[node].Spiceshell.GetSpiceFileVVAsync(proxy);
+        if (!success) { return (reasonPhrase, null); }
+
+        content = await ReplaceProxyInContentAsync(content, proxy, output);
+
+        var fileName = Path.GetTempFileName().Replace(".tmp", ".vv");
+        await File.WriteAllTextAsync(fileName, content);
+        return (null, fileName);
+    }
+
+    /// <summary>
+    /// Opens a VNC WebSocket tunnel for the given node shell and prepares a .vv file.
+    /// The caller must dispose the returned <see cref="VncWebSocketBridge"/> after the viewer exits.
+    /// </summary>
+    public static async Task<(string? Error, string? FileName, VncWebSocketBridge? Bridge)>
+        PrepareVncAsync(PveClient client, string node, TextWriter? output = null)
+    {
+        var vncResult = await client.Nodes[node].Vncshell.Vncshell(websocket: true);
+
+        if (!vncResult.IsSuccessStatusCode) { return (vncResult.ReasonPhrase, null, null); }
+
+        var ticket = (string)vncResult.Response.data.ticket;
+        var port = Convert.ToInt32(vncResult.Response.data.port);
+
+        var wsUrl = NoVncHelper.GetWebsocketUrl(client.Host,
+                                                client.Port,
+                                                node,
+                                                port,
+                                                HttpUtility.UrlEncode(ticket));
+
+        if (output != null) { await output.WriteLineAsync($"VNC WebSocket URL: {wsUrl}"); }
+
+        return await CreateVncWebSocketBridgeAsync(client, wsUrl, ticket, $"VNC: Node {node}", output);
+    }
+
+    private static async Task<(string? Error, string? FileName, VncWebSocketBridge? Bridge)>
+        CreateVncWebSocketBridgeAsync(PveClient client,
+                                      string wsUrl,
+                                      string ticket,
+                                      string title,
+                                      TextWriter? output = null)
+    {
+        var bridge = new VncWebSocketBridge();
+        bridge.Start(wsUrl, client.Host, client.PVEAuthCookie);
+
+        var vvContent = $"""
+            [virt-viewer]
+            type=vnc
+            host=127.0.0.1
+            port={bridge.LocalPort}
+            password={ticket}
+            title={title}
+            delete-this-file=1
+            """;
+
+        var fileName = Path.GetTempFileName().Replace(".tmp", ".vv");
+        await File.WriteAllTextAsync(fileName, vvContent);
+
+        if (output != null) { await output.WriteLineAsync($"VNC local port: {bridge.LocalPort}"); }
+
+        return (null, fileName, bridge);
+    }
+
+    private static async Task<string> ReplaceProxyInContentAsync(string content, string proxy, TextWriter? output)
+    {
+        if (HttpRegex().IsMatch(proxy))
+        {
+            var lines = content.Split("\n");
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].StartsWith("proxy="))
+                {
+                    lines[i] = $"proxy={proxy}";
+                    break;
+                }
+            }
+            content = string.Join("\n", lines);
+
+            if (output != null)
+            {
+                await output.WriteLineAsync($"Replace Proxy: {proxy}");
+                await output.WriteLineAsync(content);
+            }
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    /// Launches remote-viewer with the given .vv file.
+    /// </summary>
+    public static int Launch(string viewerPath,
+                             string fileName,
+                             string viewerOptions,
+                             bool waitForExit,
+                             TextWriter? output = null)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = output == null,
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            startInfo.FileName = "/bin/bash";
+            startInfo.Arguments = $"-c \"{viewerPath} {fileName} {viewerOptions}\"";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            startInfo.FileName = $"\"{viewerPath}\"";
+            startInfo.Arguments = $"\"{fileName}\" {viewerOptions}";
+        }
+
+        if (output != null)
+        {
+            output.WriteLine($"Run FileName: {startInfo.FileName}");
+            output.WriteLine($"Run Arguments: {startInfo.Arguments}");
+        }
+
+        var process = new Process { StartInfo = startInfo };
+        process.Start();
+        if (waitForExit) { process.WaitForExit(); }
+        return !process.HasExited || process.ExitCode == 0 ? 0 : 1;
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/VncWebSocketBridge.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/VncWebSocketBridge.cs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+#nullable enable
+
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+
+namespace Corsinvest.ProxmoxVE.Api.Extension.Utils;
+
+/// <summary>
+/// Bridges a Proxmox VNC WebSocket to a local TCP port so that
+/// remote-viewer (which speaks plain TCP VNC) can connect.
+/// </summary>
+public sealed class VncWebSocketBridge : IAsyncDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _acceptLoop;
+
+    /// <summary>Local TCP port that remote-viewer should connect to.</summary>
+    public int LocalPort { get; }
+
+    /// <summary>Creates the bridge and starts listening on a random local port.</summary>
+    public VncWebSocketBridge()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        LocalPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+    }
+
+    /// <summary>Connects to the Proxmox VNC WebSocket and waits for remote-viewer to connect.</summary>
+    public void Start(string wsUrl, string host, string pveAuthCookie)
+        => _acceptLoop = AcceptLoopAsync(wsUrl, host, pveAuthCookie, _cts.Token);
+
+    private async Task AcceptLoopAsync(string wsUrl, string host, string pveAuthCookie, CancellationToken ct)
+    {
+        try
+        {
+            var ws = new ClientWebSocket();
+            ws.Options.AddSubProtocol("binary");
+            var cookies = new CookieContainer();
+            cookies.Add(new Cookie("PVEAuthCookie", pveAuthCookie, "/", host) { Secure = true });
+            ws.Options.Cookies = cookies;
+            ws.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+
+            await ws.ConnectAsync(new Uri(wsUrl), ct);
+
+            using var tcp = await _listener.AcceptTcpClientAsync(ct);
+            tcp.NoDelay = true;
+
+            var stream = tcp.GetStream();
+            await Task.WhenAny(TcpToWsAsync(stream, ws, ct), WsToTcpAsync(ws, stream, ct));
+        }
+        catch { }
+    }
+
+    private static async Task TcpToWsAsync(NetworkStream src, ClientWebSocket dst, CancellationToken ct)
+    {
+        var buf = new byte[65536];
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var read = await src.ReadAsync(buf, ct);
+                if (read == 0) { break; }
+                await dst.SendAsync(buf.AsMemory(0, read), WebSocketMessageType.Binary, true, ct);
+            }
+        }
+        catch { }
+    }
+
+    private static async Task WsToTcpAsync(ClientWebSocket src, NetworkStream dst, CancellationToken ct)
+    {
+        var buf = new byte[65536];
+        try
+        {
+            while (!ct.IsCancellationRequested && src.State == WebSocketState.Open)
+            {
+                var result = await src.ReceiveAsync(buf.AsMemory(), ct);
+                if (result.MessageType == WebSocketMessageType.Close) { break; }
+                await dst.WriteAsync(buf.AsMemory(0, result.Count), ct);
+            }
+        }
+        catch { }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        if (_acceptLoop != null) { await _acceptLoop.ConfigureAwait(false); }
+        _cts.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/NoVncHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/NoVncHelper.cs
@@ -28,14 +28,14 @@ public static class NoVncHelper
     /// Get urn NoVncConsole
     /// </summary>
     public static string GetConsoleUrl(string host,
-                                   int port,
-                                   string console,
-                                   string node,
-                                   long vmId,
-                                   string vmName,
-                                   bool noVnc,
-                                   bool xtermJs,
-                                   string parameters = null)
+                                       int port,
+                                       string console,
+                                       string node,
+                                       long vmId,
+                                       string vmName,
+                                       bool noVnc,
+                                       bool xtermJs,
+                                       string parameters = null)
     {
         var url = $"https://{host}:{port}/?console={console}&vmid={vmId}&vmname={vmName}&node={node}";
         if (noVnc) { url += "&novnc=1"; }


### PR DESCRIPTION
## Summary

- Add `RemoteViewerHelper` with SPICE and VNC overloads for both VM/CT and node shell targets
- Add `VncWebSocketBridge`: bridges a Proxmox VNC WebSocket to a local TCP port so that `remote-viewer` (plain TCP VNC) can connect
- Add `GC.SuppressFinalize` to `VncWebSocketBridge.DisposeAsync`
- Align `NoVncHelper` parameter indentation

## Test plan

- [ ] Launch SPICE session for a QEMU VM via `PrepareSpiceAsync`
- [ ] Launch VNC session for a QEMU VM via `PrepareVncAsync`
- [ ] Launch SPICE/VNC session for a node shell via the node overloads
- [ ] Verify `VncWebSocketBridge` disposes cleanly (no port leak)