### PR TITLE
feat: RequestCompleted event, update-check helper, bump v9.1.15

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.14</Version>
+        <Version>9.1.14.2</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.14.2</Version>
+        <Version>9.1.15</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>
@@ -65,10 +65,10 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json"
-                          Version="13.0.3" />
+                          Version="13.0.4" />
         <PackageReference Include="System.ComponentModel.Annotations"
                           Version="5.0.0" />
         <PackageReference Include="System.CommandLine"
-                          Version="2.0.0" />
+                          Version="2.0.6" />
     </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
@@ -151,6 +151,9 @@ Good job";
     /// </summary>
     public static async Task<int> ExecuteAppAsync(this RootCommand rootCommand, string[] args, ILogger logger)
     {
+        var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
+        var (updateCheck, updateCts) = UpdateHelper.StartCheck(appName);
+
         int resultCode;
 
         try
@@ -176,6 +179,9 @@ Good job";
 
             resultCode = 1;
         }
+
+        UpdateHelper.PrintIfNewVersion(appName, updateCheck, updateCts);
+
         return resultCode;
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/ConsoleHelper.cs
@@ -151,7 +151,7 @@ Good job";
     /// </summary>
     public static async Task<int> ExecuteAppAsync(this RootCommand rootCommand, string[] args, ILogger logger)
     {
-        var resultCode = 0;
+        int resultCode;
 
         try
         {

--- a/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/UpdateHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Console/Helpers/UpdateHelper.cs
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+#nullable enable
+
+using Newtonsoft.Json;
+
+namespace Corsinvest.ProxmoxVE.Api.Console.Helpers;
+
+/// <summary>
+/// Helper for checking new GitHub releases, with 24h file cache shared across cv4pve tools.
+/// </summary>
+internal static class UpdateHelper
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+
+    private static string CacheFilePath
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".cv4pve", "update-check.json");
+
+    /// <summary>
+    /// Starts a background task that checks for a newer GitHub release (if cache is stale).
+    /// </summary>
+    public static (Task Task, CancellationTokenSource Cts) StartCheck(string appName)
+    {
+        var cts = new CancellationTokenSource();
+        var task = Task.Run(() => RefreshCacheIfStaleAsync(appName, cts.Token), cts.Token);
+        return (task, cts);
+    }
+
+    /// <summary>
+    /// Prints an update notice using the best info available (fresh fetch or cached).
+    /// Cancels the background task if still running.
+    /// </summary>
+    public static void PrintIfNewVersion(string appName, Task checkTask, CancellationTokenSource cts)
+    {
+        try
+        {
+            if (!checkTask.IsCompleted) { cts.Cancel(); }
+
+            var latestVersion = ReadCache().GetValueOrDefault(appName)?.LatestVersion;
+            if (string.IsNullOrEmpty(latestVersion)) { return; }
+
+            var currentVersion = ConsoleHelper.GetCurrentVersionApp();
+            if (latestVersion != currentVersion && !System.Console.IsOutputRedirected)
+            {
+                System.Console.Out.WriteLine();
+                System.Console.Out.WriteLine($"*** New version available: {latestVersion} (current: {currentVersion}) ***");
+            }
+        }
+        catch { }
+        finally { cts.Dispose(); }
+    }
+
+    private static async Task RefreshCacheIfStaleAsync(string appName, CancellationToken ct)
+    {
+        var cache = ReadCache();
+        if (cache.TryGetValue(appName, out var entry)
+            && DateTime.UtcNow - entry.LastCheck < CacheTtl) { return; }
+
+        string? newVersion = null;
+        try
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("cv4pve-app");
+            var json = await client.GetStringAsync($"https://api.github.com/repos/Corsinvest/{appName}/releases", ct);
+            var releases = JsonConvert.DeserializeObject<List<GitHubRelease>>(json);
+            var latest = releases?.FirstOrDefault(r => !r.Prerelease);
+            if (latest != null) { newVersion = latest.TagName.TrimStart('v'); }
+        }
+        catch { }
+
+        cache[appName] = new CacheEntry
+        {
+            LastCheck = DateTime.UtcNow,
+            LatestVersion = newVersion ?? entry?.LatestVersion ?? string.Empty
+        };
+        WriteCache(cache);
+    }
+
+    private static Dictionary<string, CacheEntry> ReadCache()
+    {
+        try
+        {
+            if (!File.Exists(CacheFilePath)) { return []; }
+            var json = File.ReadAllText(CacheFilePath);
+            return JsonConvert.DeserializeObject<Dictionary<string, CacheEntry>>(json) ?? [];
+        }
+        catch { return []; }
+    }
+
+    private static void WriteCache(Dictionary<string, CacheEntry> cache)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(CacheFilePath)!;
+            if (!Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
+            File.WriteAllText(CacheFilePath, JsonConvert.SerializeObject(cache, Formatting.Indented));
+        }
+        catch { }
+    }
+
+    private sealed class CacheEntry
+    {
+        public DateTime LastCheck { get; set; }
+        public string LatestVersion { get; set; } = string.Empty;
+    }
+
+    private sealed class GitHubRelease
+    {
+        [JsonProperty("tag_name")]
+        public string TagName { get; set; } = string.Empty;
+
+        [JsonProperty("prerelease")]
+        public bool Prerelease { get; set; }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/ClientExtension.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/ClientExtension.cs
@@ -396,7 +396,8 @@ public static class ClientExtension
                                 resource,
                                 parameters,
                                 MethodType.Create,
-                                ResponseType.Json);
+                                ResponseType.Json,
+                                TimeSpan.Zero);
 
         return result;
     }

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/ClientExtension.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/ClientExtension.cs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+using System.ComponentModel;
+using System.Dynamic;
+using System.Net.Http.Headers;
 using Corsinvest.ProxmoxVE.Api.Extension.Utils;
 using Corsinvest.ProxmoxVE.Api.Shared;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
@@ -11,9 +14,6 @@ using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 using Corsinvest.ProxmoxVE.Api.Shared.Utils;
 using Newtonsoft.Json;
-using System.ComponentModel;
-using System.Dynamic;
-using System.Net.Http.Headers;
 
 namespace Corsinvest.ProxmoxVE.Api.Extension;
 
@@ -26,14 +26,14 @@ public static class ClientExtension
     /// <summary>
     /// Get resources
     /// </summary>
-    public static async Task<IEnumerable<ClusterResource>> GetResourcesAsync(this PveClient client, ClusterResourceType resourceType)
-        => await client.Cluster.Resources.GetAsync(resourceType);
+    public static Task<IEnumerable<ClusterResource>> GetResourcesAsync(this PveClient client, ClusterResourceType resourceType)
+        => client.Cluster.Resources.GetAsync(resourceType);
 
     /// <summary>
     /// Get resource type
     /// </summary>
-    public static async Task<IEnumerable<ClusterResource>> GetResourcesAsync(this PveClient client, string type)
-        => await client.Cluster.Resources.GetAsync(type);
+    public static Task<IEnumerable<ClusterResource>> GetResourcesAsync(this PveClient client, string type)
+        => client.Cluster.Resources.GetAsync(type);
 
     /// <summary>
     /// Get host and ip
@@ -109,8 +109,8 @@ public static class ClientExtension
     /// <summary>
     /// Get VM/CT from id or name.
     /// </summary>
-    public static async Task<IClusterResourceVm> GetVmAsync(this PveClient client, long vmId)
-        => await client.GetVmAsync(vmId + string.Empty);
+    public static Task<IClusterResourceVm> GetVmAsync(this PveClient client, long vmId)
+        => client.GetVmAsync(vmId + string.Empty);
 
     /// <summary>
     /// Get VM/CT from id or name.
@@ -196,7 +196,7 @@ public static class ClientExtension
         ret = [.. ret.Distinct()];
 
         //exclude data
-        foreach (var id in jolly.Split(',').Where(a => a.StartsWith("-")).Select(a => a[1..]))
+        foreach (var id in jolly.Split(',').Where(a => a.StartsWith('-')).Select(a => a[1..]))
         {
             foreach (var item in await GetVmsFromIdAsync(id))
             {
@@ -210,8 +210,8 @@ public static class ClientExtension
     /// <summary>
     /// Change status VM/CT
     /// </summary>
-    public static async Task<Result> ChangeStatusVmAsync(this PveClient client, long vmId, string status)
-        => await client.ChangeStatusVmAsync(vmId, (VmStatus)Enum.Parse(typeof(VmStatus), status, true));
+    public static Task<Result> ChangeStatusVmAsync(this PveClient client, long vmId, string status)
+        => client.ChangeStatusVmAsync(vmId, Enum.Parse<VmStatus>(status, true));
 
     /// <summary>
     /// Change status VM/CT
@@ -322,8 +322,8 @@ public static class ClientExtension
         }
 
         var vms = resources.Where(a => a.ResourceType == ClusterResourceType.Vm && !a.IsUnknown);
-        if (addVmId) { vmIds.AddRange(vms.Select(a => a.VmId + string.Empty).OrderBy(a => a)); }
-        if (addVmName) { vmIds.AddRange(vms.Select(a => a.Name).OrderBy(a => a)); }
+        if (addVmId) { vmIds.AddRange(vms.Select(a => a.VmId + string.Empty).Order()); }
+        if (addVmName) { vmIds.AddRange(vms.Select(a => a.Name).Order()); }
 
         return vmIds.Distinct();
     }

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ClientHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/ClientHelper.cs
@@ -154,14 +154,14 @@ namespace Corsinvest.ProxmoxVE.Api.Extension.Utils
         /// <param name="httpClient">Optional HTTP client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Named tuple of client and endpoint, or (null, null) if no hosts are reachable</returns>
-        public static async Task<(PveClient client, HostEndpoint endpoint)> GetClientFromHAAsync(string hostsAndPortHA,
+        public static Task<(PveClient client, HostEndpoint endpoint)> GetClientFromHAAsync(string hostsAndPortHA,
                                                                                                  int timeout = DEFAULT_TIMEOUT,
                                                                                                  HttpClient httpClient = null,
                                                                                                  CancellationToken cancellationToken = default(CancellationToken))
-            => await GetClientFromHAAsync(hostsAndPortHA,
-                                          (host, port) => new PveClient(host, port, httpClient),
-                                          timeout,
-                                          cancellationToken);
+            => GetClientFromHAAsync(hostsAndPortHA,
+                                    (host, port) => new PveClient(host, port, httpClient),
+                                    timeout,
+                                    cancellationToken);
 
         /// <summary>
         /// Parse host endpoints from string
@@ -222,7 +222,7 @@ namespace Corsinvest.ProxmoxVE.Api.Extension.Utils
                 }
             }
 
-            if (errors.Any())
+            if (errors.Count != 0)
             {
                 throw new PveException($"No reachable hosts found. Errors: {string.Join("; ", errors)}");
             }

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/VmHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/VmHelper.cs
@@ -27,7 +27,7 @@ public static class VmHelper
     /// <param name="noVnc"></param>
     /// <param name="xtermJs"></param>
     /// <param name="parameters"></param>
-    public static async Task<HttpResponseMessage> GetConsoleNoVncAsync(PveClient client,
+    public static Task<HttpResponseMessage> GetConsoleNoVncAsync(PveClient client,
                                                                    string node,
                                                                    long vmId,
                                                                    string vmName,
@@ -35,14 +35,14 @@ public static class VmHelper
                                                                    bool noVnc,
                                                                    bool xtermJs,
                                                                    string parameters = null)
-    => await GetConsoleNoVncAsync(client,
-                                  node,
-                                  vmId,
-                                  vmName,
-                                  NoVncHelper.GetConsoleType(vmType),
-                                  noVnc,
-                                  xtermJs,
-                                  parameters);
+        => GetConsoleNoVncAsync(client,
+                                node,
+                                vmId,
+                                vmName,
+                                NoVncHelper.GetConsoleType(vmType),
+                                noVnc,
+                                xtermJs,
+                                parameters);
 
     /// <summary>
     /// Get console NoVnc
@@ -85,7 +85,7 @@ public static class VmHelper
     /// </summary>
     public static bool CheckIdOrName(IClusterResourceVm data, string vmIdOrName)
     {
-        if (vmIdOrName.Contains(":"))
+        if (vmIdOrName.Contains(':'))
         {
             //range number
             var range = vmIdOrName.Split(':');
@@ -106,9 +106,9 @@ public static class VmHelper
             var vmIdOrNameLower = vmIdOrName.Replace("%", string.Empty).ToLower();
             if (vmIdOrName.Contains('%'))
             {
-                if (vmIdOrName.StartsWith("%") && vmIdOrName.EndsWith("%")) { return name.Contains(vmIdOrNameLower); }
-                else if (vmIdOrName.StartsWith("%")) { return name.StartsWith(vmIdOrNameLower); }
-                else if (vmIdOrName.EndsWith("%")) { return name.EndsWith(vmIdOrNameLower); }
+                if (vmIdOrName.StartsWith('%') && vmIdOrName.EndsWith('%')) { return name.Contains(vmIdOrNameLower); }
+                else if (vmIdOrName.StartsWith('%')) { return name.StartsWith(vmIdOrNameLower); }
+                else if (vmIdOrName.EndsWith('%')) { return name.EndsWith(vmIdOrNameLower); }
                 else { return false; }
             }
             else
@@ -177,8 +177,8 @@ public static class VmHelper
         }
 
         var vms = resources.Where(a => a.ResourceType == ClusterResourceType.Vm && !a.IsUnknown);
-        if (addVmId) { vmIds.AddRange(vms.Select(a => a.VmId + string.Empty).OrderBy(a => a)); }
-        if (addVmName) { vmIds.AddRange(vms.Select(a => a.Name).OrderBy(a => a)); }
+        if (addVmId) { vmIds.AddRange(vms.Select(a => a.VmId + string.Empty).Order()); }
+        if (addVmName) { vmIds.AddRange(vms.Select(a => a.Name).Order()); }
 
         return vmIds.Distinct();
     }

--- a/src/Corsinvest.ProxmoxVE.Api.Metadata/GeneratorClassApi.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Metadata/GeneratorClassApi.cs
@@ -36,11 +36,9 @@ public static class GeneratorClassApi
         var url = $"https://{host}:{port}/pve-docs/api-viewer/apidoc.js";
         var json = new StringBuilder();
 
-#pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
         using (var httpClientHandler = new HttpClientHandler
         {
-            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
-#pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
         })
         using (var client = new HttpClient(httpClientHandler))
         using (var response = await client.GetAsync(url))
@@ -100,11 +98,11 @@ public static class GeneratorClassApi
             var path = kv.Key;
             var info = kv.Value;
             var segments = path.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
-            var name = segments.Last();
-            var isIndexed = name.StartsWith("{");
+            var name = segments[^1];
+            var isIndexed = name.StartsWith('{');
 
             // Find or create parent node
-            var parentPath = "/" + string.Join("/", segments.Take(segments.Length - 1).ToArray());
+            var parentPath = "/" + string.Join("/", [.. segments.Take(segments.Length - 1)]);
             var parent = segments.Length == 1
                             ? root
                             : ClassApi.GetFromResource(root, parentPath) ?? root;

--- a/src/Corsinvest.ProxmoxVE.Api.Metadata/ParameterApi.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Metadata/ParameterApi.cs
@@ -27,7 +27,7 @@ public class ParameterApi
         Description = flat.Description ?? string.Empty;
         Optional = flat.Optional ?? false;
         Default = flat.Default ?? string.Empty;
-        Minimum = flat.Minimum.HasValue ? flat.Minimum.Value : null;
+        Minimum = flat.Minimum;
         Maximum = flat.Maximum;
         EnumValues = flat.EnumValues ?? [];
     }

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterExtension.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterExtension.cs
@@ -95,7 +95,7 @@ public static class ClusterExtension
         {
             itemVm.EnrichData(itemVm.Status);
 
-            itemVm.VmType = (VmType)Enum.Parse(typeof(VmType), itemVm.Type, true);
+            itemVm.VmType = Enum.Parse<VmType>(itemVm.Type, true);
         }
         else if (data.ResourceType == ClusterResourceType.Node && data is IClusterResourceNode itemNode)
         {

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/CpuX86Level.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Utils/CpuX86Level.cs
@@ -8,7 +8,7 @@ namespace Corsinvest.ProxmoxVE.Api.Shared.Utils;
 /// <summary>
 /// x86-64 CPU compatibility level for safe live migration across cluster nodes.
 /// </summary>
-public class CpuX86Level : IComparable<CpuX86Level>
+public sealed class CpuX86Level : IComparable<CpuX86Level>
 {
     /// <summary>x86-64-v1 — any x86-64 CPU</summary>
     public static readonly CpuX86Level V1 = new(1, "x86-64-v1");
@@ -28,7 +28,7 @@ public class CpuX86Level : IComparable<CpuX86Level>
     private CpuX86Level(int level, string name) { Level = level; Name = name; }
 
     /// <inheritdoc/>
-    public int CompareTo(CpuX86Level other) => Level.CompareTo(other == null ? 0 : other.Level);
+    public int CompareTo(CpuX86Level other) => Level.CompareTo((other?.Level) ?? 0);
 
     /// <inheritdoc/>
     public override string ToString() => Name;

--- a/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
@@ -443,7 +443,6 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
     /// <summary>
     /// Raised after each API request completes. Fires for both successful and failed requests
     /// (including transport-level failures, which are translated into a synthetic <see cref="Result"/>
-    /// with <see cref="HttpStatusCode.RequestTimeout"/> or <see cref="HttpStatusCode.InternalServerError"/>).
     /// </summary>
     public event EventHandler<Result> RequestCompleted;
 

--- a/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/PveClientBase.cs
@@ -432,10 +432,20 @@ public class PveClientBase(string host, int port = 8006, HttpClient? httpClient 
                                 resource,
                                 parameters,
                                 methodType,
-                                ResponseType);
+                                ResponseType,
+                                sw.Elapsed);
+
+        RequestCompleted?.Invoke(this, LastResult);
 
         return LastResult;
     }
+
+    /// <summary>
+    /// Raised after each API request completes. Fires for both successful and failed requests
+    /// (including transport-level failures, which are translated into a synthetic <see cref="Result"/>
+    /// with <see cref="HttpStatusCode.RequestTimeout"/> or <see cref="HttpStatusCode.InternalServerError"/>).
+    /// </summary>
+    public event EventHandler<Result> RequestCompleted;
 
     /// <summary>
     /// Last result action

--- a/src/Corsinvest.ProxmoxVE.Api/Result.cs
+++ b/src/Corsinvest.ProxmoxVE.Api/Result.cs
@@ -19,7 +19,8 @@ public class Result(dynamic response,
                     string requestResource,
                     IDictionary<string, object> requestParameters,
                     MethodType methodType,
-                    ResponseType responseType)
+                    ResponseType responseType,
+                    TimeSpan duration)
 {
     /// <summary>
     /// Method type
@@ -70,6 +71,11 @@ public class Result(dynamic response,
     /// Gets a value that indicates if the HTTP response was successful.
     /// </summary>
     public bool IsSuccessStatusCode { get; } = isSuccessStatusCode;
+
+    /// <summary>
+    /// Total wall-clock duration of the request.
+    /// </summary>
+    public TimeSpan Duration { get; } = duration;
 
     /// <summary>
     /// Get error


### PR DESCRIPTION
## Summary

### New features
- **`PveClientBase.RequestCompleted` event** — raised after every API request (success or failure); receives the full `Result`.
- **`Result.Duration`** (new `TimeSpan` property) — wall-clock duration of the request.
- **`UpdateHelper`** — background GitHub releases check with 24h file cache at `~/.cv4pve/update-check.json`, shared across cv4pve CLI tools. Prints a notice on stdout only when stdout is not redirected. Survives offline runs (stores `lastCheck` even on failure).

### Cleanup
- Remove superfluous `async/await` in `ClientExtension`, `VmHelper`, `ClientHelper`.
- Use char literals in `StartsWith/EndsWith/Contains`, `.Order()` instead of `.OrderBy(x => x)`, `Enum.Parse<T>(...)`.
- `HttpClientHandler.DangerousAcceptAnyServerCertificateValidator` instead of pragma disable.
- `CpuX86Level` → `sealed`.

## Test plan

- [ ] Subscribe to `RequestCompleted` and verify fires for both successful and failed requests with correct `Duration`.
- [ ] Run a console tool once → verify `~/.cv4pve/update-check.json` created with `lastCheck` and `latestVersion`.
- [ ] Run the tool again within 24h → verify no GitHub call (check network monitor).
- [ ] Run with `> file.txt` → verify no update notice in the file.
- [ ] Run offline → verify no crash, cache updated with empty `latestVersion`.