### PR TITLE
fix(VmConfig): guard ReadNetworks/ReadDisks against null ExtensionData

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
@@ -136,6 +136,12 @@ public partial class VmConfig : ModelBase
     {
         var networks = new List<VmNetwork>();
 
+        if (ExtensionData == null)
+        {
+            Networks = networks;
+            return;
+        }
+
         foreach (var key in ExtensionData.Keys)
         {
             if (key.StartsWith("net"))
@@ -252,6 +258,13 @@ public partial class VmConfig : ModelBase
     private void ReadDisks()
     {
         var disks = new List<VmDisk>();
+
+        if (ExtensionData == null)
+        {
+            Disks = disks;
+            return;
+        }
+
         foreach (var key in ExtensionData.Keys)
         {
             var def = ExtensionData[key] + string.Empty;


### PR DESCRIPTION
## Summary
- `ReadNetworks()` and `ReadDisks()` no longer throw `NullReferenceException` when `ExtensionData` is null
- Both methods now early-return with an empty list, preserving the previous post-condition that `Networks`/`Disks` are always non-null

## Test plan
- [ ] Call `VmConfig` parsing on a payload that does not include `ExtensionData` and verify `Networks`/`Disks` are empty lists