### PR TITLE
fix(models): widen Unix timestamp fields from int to long (Y2K38)

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Access/AccessUser.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Access/AccessUser.cs
@@ -28,7 +28,7 @@ public class AccessUser : ModelBase
     /// Account expiration date (seconds since epoch). '0' means no expiration date.
     /// </summary>
     [JsonProperty("expire")]
-    public int Expire { get; set; }
+    public long Expire { get; set; }
 
     /// <summary>
     /// Email
@@ -105,7 +105,7 @@ public class AccessUser : ModelBase
         /// Account expiration date (seconds since epoch). '0' means no expiration date.
         /// </summary>
         [JsonProperty("expire")]
-        public int Expire { get; set; }
+        public long Expire { get; set; }
         /// <summary>
         /// Token Name
         /// </summary>

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterBackup.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterBackup.cs
@@ -110,10 +110,10 @@ public class ClusterBackup : ModelBase, IStorageItem
     public string NotesTemplate { get; set; }
 
     /// <summary>
-    /// NextRun
+    /// NextRun (seconds since epoch)
     /// </summary>
     [JsonProperty("next-run")]
-    public int NextRun { get; set; }
+    public long NextRun { get; set; }
 
     /// <summary>
     /// Node

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterLog.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Cluster/ClusterLog.cs
@@ -73,7 +73,7 @@ public class ClusterLog : ModelBase
     /// </summary>
     [JsonProperty("time")]
     [DisplayFormat(DataFormatString = FormatHelper.DataFormatUnixTime)]
-    public int Time { get; set; }
+    public long Time { get; set; }
 
     /// <summary>
     /// Time

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeReplication.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeReplication.cs
@@ -52,7 +52,7 @@ public class NodeReplication : ModelBase
     /// Last Sync
     /// </summary>
     [JsonProperty("last_sync")]
-    public int LastSync { get; set; }
+    public long LastSync { get; set; }
 
     /// <summary>
     /// Job Num
@@ -64,7 +64,7 @@ public class NodeReplication : ModelBase
     /// Next Sync
     /// </summary>
     [JsonProperty("next_sync")]
-    public int NextSync { get; set; }
+    public long NextSync { get; set; }
 
     /// <summary>
     /// Guest
@@ -94,7 +94,7 @@ public class NodeReplication : ModelBase
     /// Last Try
     /// </summary>
     [JsonProperty("last_try")]
-    public int LastTry { get; set; }
+    public long LastTry { get; set; }
 
     /// <summary>
     /// Target

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeStatus.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeStatus.cs
@@ -61,7 +61,7 @@ public class NodeStatus : ModelBase
     /// </summary>
     [JsonProperty("uptime")]
     [DisplayFormat(DataFormatString = FormatHelper.DataFormatUptimeUnixTime)]
-    public int Uptime { get; set; }
+    public long Uptime { get; set; }
 
     /// <summary>
     /// An array of load avg for 1, 5 and 15 minutes respectively.

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeStorageRrdData.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeStorageRrdData.cs
@@ -26,7 +26,7 @@ public class NodeStorageRrdData : ModelBase
     /// </summary>
     [JsonProperty("time")]
     [DisplayFormat(DataFormatString = FormatHelper.DataFormatUnixTime)]
-    public int Time { get; set; }
+    public long Time { get; set; }
 
     /// <summary>
     /// Size


### PR DESCRIPTION
## Summary
- Promote Unix-timestamp fields from `int` to `long` to avoid Y2K38 overflow
- Affected fields:
  - `AccessUser.Expire` and `AccessUser.Token.Expire`
  - `ClusterBackup.NextRun` (also clarified XML doc: `seconds since epoch`)
  - `ClusterLog.Time`
  - `NodeReplication.LastSync`, `NextSync`, `LastTry`
  - `NodeStatus.Uptime`
  - `NodeStorageRrdData.Time`
- Newtonsoft.Json deserializes JSON numbers into `long` without issue, so no wire-format breakage

## Test plan
- [ ] Deserialize sample payloads for each affected model and verify values round-trip