### PR TITLE
feat(VmConfig): add GetDisk lookup, treat efidisk0/tpmstate0 as disks

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
@@ -121,6 +121,12 @@ public partial class VmConfig : ModelBase
     public IEnumerable<VmDisk> Disks { get; private set; } = [];
 
     /// <summary>
+    /// Lookup a disk by its id (e.g. <c>"scsi0"</c>, <c>"efidisk0"</c>, <c>"tpmstate0"</c>, <c>"rootfs"</c>).
+    /// Returns null when no disk with that id is configured.
+    /// </summary>
+    public VmDisk GetDisk(string id) => Disks.FirstOrDefault(d => d.Id == id);
+
+    /// <summary>
     /// Networks
     /// </summary>
     public IEnumerable<VmNetwork> Networks { get; private set; } = [];

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfigQemu.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfigQemu.cs
@@ -261,12 +261,6 @@ public class VmConfigQemu : VmConfig
     public string Ciuser { get; set; }
 
     /// <summary>
-    /// Configure a disk for storing EFI vars.
-    /// </summary>
-    [JsonProperty("efidisk0")]
-    public string Efidisk0 { get; set; }
-
-    /// <summary>
     /// Freeze CPU at startup (use 'c' monitor command to start execution).
     /// </summary>
     [JsonProperty("freeze")]
@@ -379,12 +373,6 @@ public class VmConfigQemu : VmConfig
     /// </summary>
     [JsonProperty("startdate")]
     public string Startdate { get; set; }
-
-    /// <summary>
-    /// Configure a Disk for storing TPM state. The format is fixed to 'raw'.
-    /// </summary>
-    [JsonProperty("tpmstate0")]
-    public string Tpmstate0 { get; set; }
 
     /// <summary>
     /// Set VM Generation ID. Use '1' to autogenerate on create or update, pass '0' to disable explicitly.


### PR DESCRIPTION
## Summary
- New `VmConfig.GetDisk(string id)` returns the configured `VmDisk` for a given id (e.g. `scsi0`, `efidisk0`, `tpmstate0`, `rootfs`), or `null` when not present
- Remove standalone `Efidisk0` / `Tpmstate0` string properties from `VmConfigQemu`: they are dedicated disks already populated into the base `Disks` collection by `ReadDisks`, so consumers should access them via `GetDisk("efidisk0")` / `GetDisk("tpmstate0")` for parity with the other disk slots

Related: Corsinvest/cv4pve-report#37

## Test plan
- [ ] `GetDisk("scsi0")` returns the disk when present, `null` otherwise
- [ ] `GetDisk("efidisk0")` and `GetDisk("tpmstate0")` return the corresponding `VmDisk` parsed from `ExtensionData`
- [ ] Build cv4pve-report against this branch and verify the report still renders EFI and TPM state info via `GetDisk`