### PR TITLE
fix(VmConfig): correct LXC backup defaults for rootfs and mp

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Vm/VmConfig.cs
@@ -308,15 +308,13 @@ public partial class VmConfig : ModelBase
                     storage = infos[0];
                 }
 
-                var backup = false;
-                if (this is VmConfigQemu)
-                {
-                    backup = !infos.Contains("backup=0");
-                }
-                else if (this is VmConfigLxc)
-                {
-                    backup = infos.Contains("backup=1");
-                }
+                // Proxmox defaults for the 'backup' flag:
+                //   Qemu disks: included unless backup=0
+                //   LXC rootfs: always included (no backup property exists for rootfs)
+                //   LXC mp*:    excluded unless backup=1
+                var backup = this is VmConfigLxc
+                    ? key == "rootfs" || infos.Contains("backup=1")
+                    : !infos.Contains("backup=0");
 
                 disks.Add(new VmDisk
                 {


### PR DESCRIPTION
## Summary
- Fix false positives where LXC `rootfs` disks were flagged as backup-disabled. Proxmox does not write `backup=1` for `rootfs` (the property does not exist there) and rootfs is always included in backups.
- Aligned the `VmConfig` disk parser with the actual Proxmox defaults:
  - Qemu disks: included unless `backup=0`
  - LXC `rootfs`: always included
  - LXC `mp*`: excluded unless `backup=1`

Refs Corsinvest/cv4pve-diag#37 (do not close — the diag repo will pick up the SDK bump separately).

## Test plan
- [ ] Run cv4pve-diag against a cluster with LXC containers whose `rootfs` has no `backup=` flag and confirm CG0002 no longer fires for them.
- [ ] Confirm CG0002 still fires for Qemu disks with `backup=0` and LXC mountpoints without `backup=1`.