### PR TITLE
Release v9.1.18

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.17</Version>
+        <Version>9.1.18</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>


### PR DESCRIPTION
## Release v9.1.18

Bump `<Version>` from 9.1.17 to 9.1.18.

### Shipped in this release
- #80 fix(VmConfig): correct LXC backup defaults for rootfs and mp
- #81 feat(VmConfig): expose CD-ROM/cloud-init drives via DisksAll and Kind enum
- #82 refactor(NetworkDiagramBuilder): split into partials, palette and comments

### Post-merge
- [ ] Tag `v9.1.18` and push to trigger the release workflow