### PR TITLE
Release v9.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Version>9.1.18</Version>
+        <Version>9.2.0</Version>
         <!-- <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn> -->
         <Company>Corsinvest Srl</Company>
         <Authors>Corsinvest Srl</Authors>


### PR DESCRIPTION
## Release v9.2.0

Version bump 9.1.18 → 9.2.0.

### Included (already merged via #84)
- Regenerated `PveClient` for Proxmox VE 9.x schema (SDN prefix-lists/route-maps, cluster/qemu CPU models, HA arm/disarm, OIDC params, capabilities/qemu/*)
- New `ClusterResourceHealthExtensions` (health score 0–100 for Node/VM/Storage)

### ⚠️ Breaking (parameter level)
- `max_workers` replaces `maxworkers`
- dropped deprecated `maxfiles` from vzdump / backup

This PR contains only the version bump, per release convention.