### PR TITLE
feat(extension): PveCalendarEvent parser with full PVE/systemd schedule support

### DIFF
--- a/Corsinvest.ProxmoxVE.Api.slnx
+++ b/Corsinvest.ProxmoxVE.Api.slnx
@@ -17,6 +17,7 @@
   <Folder Name="/src/">
     <Project Path="src/Corsinvest.ProxmoxVE.Api.Console/Corsinvest.ProxmoxVE.Api.Console.csproj" />
     <Project Path="src/Corsinvest.ProxmoxVE.Api.Extension/Corsinvest.ProxmoxVE.Api.Extension.csproj" />
+    <Project Path="src/Corsinvest.ProxmoxVE.Api.Extension.Tests/Corsinvest.ProxmoxVE.Api.Extension.Tests.csproj" />
     <Project Path="src/Corsinvest.ProxmoxVE.Api.Metadata/Corsinvest.ProxmoxVE.Api.Metadata.csproj" />
     <Project Path="src/Corsinvest.ProxmoxVE.Api.Shared/Corsinvest.ProxmoxVE.Api.Shared.csproj" />
     <Project Path="src/Corsinvest.ProxmoxVE.Api.Test/Corsinvest.ProxmoxVE.Api.Test.csproj" />

--- a/src/Corsinvest.ProxmoxVE.Api.Extension.Tests/Corsinvest.ProxmoxVE.Api.Extension.Tests.csproj
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension.Tests/Corsinvest.ProxmoxVE.Api.Extension.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Product>Corsinvest for Proxmox VE Api Client Extension Tests</Product>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Corsinvest.ProxmoxVE.Api.Extension\Corsinvest.ProxmoxVE.Api.Extension.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/Corsinvest.ProxmoxVE.Api.Extension.Tests/PveCalendarEventTests.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension.Tests/PveCalendarEventTests.cs
@@ -1,0 +1,342 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+using Corsinvest.ProxmoxVE.Api.Extension.Scheduling;
+using Xunit;
+
+namespace Corsinvest.ProxmoxVE.Api.Extension.Tests;
+
+public class PveCalendarEventTests
+{
+    // shortcuts
+
+    [Fact]
+    public void Minutely_matches_every_minute()
+    {
+        var c = PveCalendarEvent.Parse("minutely");
+        Assert.Equal(24, c.Hours.Count);
+        Assert.Equal(60, c.Minutes.Count);
+    }
+
+    [Fact]
+    public void Hourly_matches_top_of_every_hour()
+    {
+        var c = PveCalendarEvent.Parse("hourly");
+        Assert.Equal(24, c.Hours.Count);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Daily_is_midnight_every_day()
+    {
+        var c = PveCalendarEvent.Parse("daily");
+        Assert.Equal([0], c.Hours);
+        Assert.Equal([0], c.Minutes);
+        Assert.Equal(12, c.Months.Count);
+        Assert.Equal(31, c.DaysOfMonth.Count);
+        Assert.Equal(7, c.DaysOfWeek.Count);
+    }
+
+    [Fact]
+    public void Weekly_is_monday_midnight()
+    {
+        var c = PveCalendarEvent.Parse("weekly");
+        Assert.Equal([1], c.DaysOfWeek); // monday
+        Assert.Equal([0], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Monthly_is_first_of_month_midnight()
+    {
+        var c = PveCalendarEvent.Parse("monthly");
+        Assert.Equal([1], c.DaysOfMonth);
+        Assert.Equal(12, c.Months.Count);
+        Assert.Equal([0], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Yearly_is_january_first_midnight()
+    {
+        var c = PveCalendarEvent.Parse("yearly");
+        Assert.Equal([1], c.Months);
+        Assert.Equal([1], c.DaysOfMonth);
+        Assert.Equal([0], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Annually_is_alias_for_yearly()
+    {
+        var a = PveCalendarEvent.Parse("annually");
+        var y = PveCalendarEvent.Parse("yearly");
+        Assert.Equal(a.Months, y.Months);
+        Assert.Equal(a.DaysOfMonth, y.DaysOfMonth);
+    }
+
+    [Fact]
+    public void Quarterly_is_jan_apr_jul_oct_first()
+    {
+        var c = PveCalendarEvent.Parse("quarterly");
+        Assert.Equal([1, 4, 7, 10], c.Months);
+        Assert.Equal([1], c.DaysOfMonth);
+    }
+
+    [Fact]
+    public void Semiannually_is_jan_jul_first()
+    {
+        var c = PveCalendarEvent.Parse("semiannually");
+        Assert.Equal([1, 7], c.Months);
+        Assert.Equal([1], c.DaysOfMonth);
+    }
+
+    // weekdays
+
+    [Theory]
+    [InlineData("sun", 0)]
+    [InlineData("mon", 1)]
+    [InlineData("tue", 2)]
+    [InlineData("wed", 3)]
+    [InlineData("thu", 4)]
+    [InlineData("fri", 5)]
+    [InlineData("sat", 6)]
+    public void Single_weekday_token(string token, int expected)
+    {
+        var c = PveCalendarEvent.Parse($"{token} 00:00");
+        Assert.Equal([expected], c.DaysOfWeek);
+    }
+
+    [Fact]
+    public void Weekday_range_mon_to_fri()
+    {
+        var c = PveCalendarEvent.Parse("mon..fri 09:00");
+        Assert.Equal([1, 2, 3, 4, 5], c.DaysOfWeek);
+        Assert.Equal([9], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Weekday_list_mon_wed_fri()
+    {
+        var c = PveCalendarEvent.Parse("mon,wed,fri 14:30");
+        Assert.Equal([1, 3, 5], c.DaysOfWeek);
+        Assert.Equal([14], c.Hours);
+        Assert.Equal([30], c.Minutes);
+    }
+
+    [Fact]
+    public void Weekday_no_prefix_means_all_days()
+    {
+        var c = PveCalendarEvent.Parse("02:00");
+        Assert.Equal(7, c.DaysOfWeek.Count);
+    }
+
+    // time HH:MM
+
+    [Fact]
+    public void Simple_hour_minute()
+    {
+        var c = PveCalendarEvent.Parse("09:00");
+        Assert.Equal([9], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Wildcard_hour_specific_minute()
+    {
+        var c = PveCalendarEvent.Parse("*:30");
+        Assert.Equal(24, c.Hours.Count);
+        Assert.Equal([30], c.Minutes);
+    }
+
+    [Fact]
+    public void Step_every_15_minutes()
+    {
+        var c = PveCalendarEvent.Parse("*:0/15");
+        Assert.Equal(24, c.Hours.Count);
+        Assert.Equal([0, 15, 30, 45], c.Minutes);
+    }
+
+    [Fact]
+    public void Step_every_4_hours()
+    {
+        var c = PveCalendarEvent.Parse("0/4:00");
+        Assert.Equal([0, 4, 8, 12, 16, 20], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Hour_list()
+    {
+        var c = PveCalendarEvent.Parse("9,12,15:00");
+        Assert.Equal([9, 12, 15], c.Hours);
+    }
+
+    [Fact]
+    public void Hour_range()
+    {
+        var c = PveCalendarEvent.Parse("9..17:00");
+        Assert.Equal(Enumerable.Range(9, 9), c.Hours.OrderBy(x => x));
+    }
+
+    // date spec
+
+    [Fact]
+    public void Systemd_full_wildcard_is_daily()
+    {
+        var c = PveCalendarEvent.Parse("*-*-* 02:00");
+        Assert.Equal(12, c.Months.Count);
+        Assert.Equal(31, c.DaysOfMonth.Count);
+        Assert.Equal([2], c.Hours);
+        Assert.Equal([0], c.Minutes);
+    }
+
+    [Fact]
+    public void Date_spec_month_day()
+    {
+        var c = PveCalendarEvent.Parse("12-25 00:00");
+        Assert.Equal([12], c.Months);
+        Assert.Equal([25], c.DaysOfMonth);
+    }
+
+    [Fact]
+    public void Date_spec_wildcard_month_specific_day()
+    {
+        var c = PveCalendarEvent.Parse("*-15 12:00");
+        Assert.Equal(12, c.Months.Count);
+        Assert.Equal([15], c.DaysOfMonth);
+    }
+
+    // utc
+
+    [Fact]
+    public void Trailing_utc_is_recorded()
+    {
+        var c = PveCalendarEvent.Parse("09:00 utc");
+        Assert.True(c.Utc);
+        Assert.Equal([9], c.Hours);
+    }
+
+    [Fact]
+    public void Without_utc_flag_is_false()
+    {
+        var c = PveCalendarEvent.Parse("09:00");
+        Assert.False(c.Utc);
+    }
+
+    // matches / next
+
+    [Fact]
+    public void Matches_works_for_quarterly()
+    {
+        var c = PveCalendarEvent.Parse("quarterly");
+        Assert.True(c.Matches(new DateTime(2026, 1, 1, 0, 0, 0)));
+        Assert.True(c.Matches(new DateTime(2026, 4, 1, 0, 0, 0)));
+        Assert.True(c.Matches(new DateTime(2026, 7, 1, 0, 0, 0)));
+        Assert.True(c.Matches(new DateTime(2026, 10, 1, 0, 0, 0)));
+        Assert.False(c.Matches(new DateTime(2026, 2, 1, 0, 0, 0)));
+        Assert.False(c.Matches(new DateTime(2026, 1, 2, 0, 0, 0)));
+        Assert.False(c.Matches(new DateTime(2026, 1, 1, 1, 0, 0)));
+    }
+
+    [Fact]
+    public void Matches_respects_weekday()
+    {
+        var c = PveCalendarEvent.Parse("mon..fri 09:00");
+        // 2026-06-01 is monday
+        Assert.True(c.Matches(new DateTime(2026, 6, 1, 9, 0, 0)));
+        // 2026-06-06 is saturday
+        Assert.False(c.Matches(new DateTime(2026, 6, 6, 9, 0, 0)));
+    }
+
+    [Fact]
+    public void NextOccurrence_for_weekly()
+    {
+        var c = PveCalendarEvent.Parse("weekly");
+        // start sun 2026-06-07 14:00; next monday midnight is 2026-06-08 00:00
+        var next = c.NextOccurrence(new DateTime(2026, 6, 7, 14, 0, 0));
+        Assert.Equal(new DateTime(2026, 6, 8, 0, 0, 0), next);
+    }
+
+    [Fact]
+    public void NextOccurrence_for_step()
+    {
+        var c = PveCalendarEvent.Parse("*:0/15");
+        var next = c.NextOccurrence(new DateTime(2026, 6, 1, 10, 7, 0));
+        Assert.Equal(new DateTime(2026, 6, 1, 10, 15, 0), next);
+    }
+
+    // tryparse
+
+    [Fact]
+    public void TryParse_returns_true_on_valid()
+    {
+        Assert.True(PveCalendarEvent.TryParse("daily", out var c));
+        Assert.NotNull(c);
+    }
+
+    [Fact]
+    public void TryParse_returns_false_on_invalid()
+    {
+        Assert.False(PveCalendarEvent.TryParse("garbage", out var c));
+        Assert.Null(c);
+    }
+
+    // error cases
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("garbage")]
+    [InlineData("25:00")]              // hour out of range
+    [InlineData("12:99")]              // minute out of range
+    [InlineData("mon..sun 09:00")]    // reversed range
+    [InlineData("13-01 00:00")]       // invalid month
+    [InlineData("01-32 00:00")]       // invalid day
+    [InlineData("2024-01-15 09:00")]  // fixed-year date is not supported
+    [InlineData("09:00 foo")]          // trailing garbage
+    [InlineData("utc")]                // utc alone
+    public void Parse_throws_on_invalid_input(string input)
+    {
+        Assert.Throws<PveCalendarParseException>(() => PveCalendarEvent.Parse(input));
+    }
+
+    [Fact]
+    public void Exception_carries_input_and_reason()
+    {
+        var ex = Assert.Throws<PveCalendarParseException>(() => PveCalendarEvent.Parse("25:00"));
+        Assert.Equal("25:00", ex.Input);
+        Assert.Contains("hour", ex.Reason);
+    }
+
+    // real-world PVE schedules
+
+    [Theory]
+    [InlineData("mon 02:00")]            // weekly backup monday 2am
+    [InlineData("sat 23:00")]            // weekly backup saturday late
+    [InlineData("*:0/15")]               // replication every 15 minutes
+    [InlineData("0/4:00")]               // every 4 hours
+    [InlineData("*-*-* 02:00")]          // daily 2am explicit
+    [InlineData("mon,wed,fri 06:30")]    // selected days
+    [InlineData("mon..fri 22:00")]       // weekdays evening
+    [InlineData("01-01 00:00")]          // jan 1st
+    [InlineData("daily")]
+    [InlineData("hourly")]
+    [InlineData("weekly")]
+    [InlineData("monthly")]
+    [InlineData("yearly")]
+    [InlineData("quarterly")]
+    public void Common_pve_schedules_parse_without_error(string schedule)
+    {
+        var c = PveCalendarEvent.Parse(schedule);
+        Assert.NotNull(c);
+        Assert.NotEmpty(c.Months);
+        Assert.NotEmpty(c.DaysOfMonth);
+        Assert.NotEmpty(c.DaysOfWeek);
+        Assert.NotEmpty(c.Hours);
+        Assert.NotEmpty(c.Minutes);
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Scheduling/PveCalendarEvent.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Scheduling/PveCalendarEvent.cs
@@ -1,0 +1,339 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace Corsinvest.ProxmoxVE.Api.Extension.Scheduling;
+
+/// <summary>
+/// Parsed PVE calendar event (systemd OnCalendar subset used by Proxmox VE
+/// for backup / replication / job schedules).
+///
+/// Supports:
+///   shortcuts: minutely, hourly, daily, weekly, monthly, quarterly, semiannually, yearly/annually
+///   weekdays:  sun..sat, ranges (mon..fri), lists (mon,wed,fri)
+///   time:      HH:MM, *:MM, HH:*, *:0/15, 0/4:00, lists, ranges
+///   date:      *-*-*, MM-DD (wildcards), with optional weekday prefix
+///   trailing 'utc' suffix (parsed and recorded; no timezone conversion)
+///
+/// Fixed dates (YYYY-MM-DD) are NOT supported (not expressible as a recurring schedule).
+/// </summary>
+public sealed partial class PveCalendarEvent
+{
+    /// <summary>Canonical weekday names in PVE order (sun=0 … sat=6).</summary>
+    public static readonly string[] WeekdayNames = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+    /// <summary>Months that match (1..12).</summary>
+    public IReadOnlySet<int> Months { get; }
+
+    /// <summary>Days of month that match (1..31).</summary>
+    public IReadOnlySet<int> DaysOfMonth { get; }
+
+    /// <summary>Days of week that match (0=sun … 6=sat).</summary>
+    public IReadOnlySet<int> DaysOfWeek { get; }
+
+    /// <summary>Hours that match (0..23).</summary>
+    public IReadOnlySet<int> Hours { get; }
+
+    /// <summary>Minutes that match (0..59).</summary>
+    public IReadOnlySet<int> Minutes { get; }
+
+    /// <summary>True when the original input had a trailing 'utc' qualifier.</summary>
+    public bool Utc { get; }
+
+    /// <summary>Original input string (after trim, before normalization).</summary>
+    public string Source { get; }
+
+    private PveCalendarEvent(string source, bool utc,
+                             IReadOnlySet<int> months,
+                             IReadOnlySet<int> dom,
+                             IReadOnlySet<int> dow,
+                             IReadOnlySet<int> hours,
+                             IReadOnlySet<int> minutes)
+    {
+        Source = source;
+        Utc = utc;
+        Months = months;
+        DaysOfMonth = dom;
+        DaysOfWeek = dow;
+        Hours = hours;
+        Minutes = minutes;
+    }
+
+    /// <summary>
+    /// Parse a PVE calendar event. Throws <see cref="PveCalendarParseException"/> on failure.
+    /// </summary>
+    public static PveCalendarEvent Parse(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new PveCalendarParseException(input ?? "", "empty input");
+        }
+
+        var original = input.Trim();
+        var normalized = ExpandShortcut(original.ToLowerInvariant());
+
+        var tokens = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+        if (tokens.Count == 0)
+        {
+            throw new PveCalendarParseException(original, "no tokens after normalization");
+        }
+
+        var utc = false;
+        if (tokens[^1] == "utc")
+        {
+            utc = true;
+            tokens.RemoveAt(tokens.Count - 1);
+            if (tokens.Count == 0)
+            {
+                throw new PveCalendarParseException(original, "'utc' without preceding spec");
+            }
+        }
+
+        var dowSet = AllDaysOfWeek();
+        if (IsWeekdayToken(tokens[0]))
+        {
+            dowSet = ParseWeekdayList(tokens[0], original);
+            tokens.RemoveAt(0);
+            if (tokens.Count == 0)
+            {
+                throw new PveCalendarParseException(original, "missing time after weekday spec");
+            }
+        }
+
+        var months = AllMonths();
+        var dom = AllDaysOfMonth();
+        if (IsDateSpecToken(tokens[0]))
+        {
+            (months, dom) = ParseDateSpec(tokens[0], original);
+            tokens.RemoveAt(0);
+            if (tokens.Count == 0)
+            {
+                throw new PveCalendarParseException(original, "missing time after date spec");
+            }
+        }
+
+        var (hours, minutes) = ParseTime(tokens[0], original);
+
+        if (tokens.Count > 1)
+        {
+            throw new PveCalendarParseException(original, $"unexpected trailing tokens: {string.Join(' ', tokens.Skip(1))}");
+        }
+
+        return new PveCalendarEvent(original, utc, months, dom, dowSet, hours, minutes);
+    }
+
+    /// <summary>
+    /// Try to parse a PVE calendar event. Returns true on success.
+    /// </summary>
+    public static bool TryParse(string input, [NotNullWhen(true)] out PveCalendarEvent? result)
+    {
+        try
+        {
+            result = Parse(input);
+            return true;
+        }
+        catch (PveCalendarParseException)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the given moment matches this calendar event.
+    /// Seconds are ignored.
+    /// </summary>
+    public bool Matches(DateTime moment)
+        => Months.Contains(moment.Month)
+        && DaysOfMonth.Contains(moment.Day)
+        && DaysOfWeek.Contains((int)moment.DayOfWeek)
+        && Hours.Contains(moment.Hour)
+        && Minutes.Contains(moment.Minute);
+
+    /// <summary>
+    /// Returns the next occurrence at or after <paramref name="from"/> (truncated to minute),
+    /// or null if no occurrence exists within one year (defensive bound for malformed schedules).
+    /// </summary>
+    public DateTime? NextOccurrence(DateTime from)
+    {
+        var candidate = new DateTime(from.Year, from.Month, from.Day, from.Hour, from.Minute, 0, from.Kind);
+        var limit = candidate.AddYears(1);
+        while (candidate <= limit)
+        {
+            if (Matches(candidate)) { return candidate; }
+            candidate = candidate.AddMinutes(1);
+        }
+        return null;
+    }
+
+    // shortcut expansion
+
+    private static string ExpandShortcut(string s) => s switch
+    {
+        "minutely" => "*:*",
+        "hourly" => "*:00",
+        "daily" => "*-*-* 00:00",
+        "weekly" => "mon *-*-* 00:00",
+        "monthly" => "*-*-01 00:00",
+        "quarterly" => "*-01,04,07,10-01 00:00",
+        "semiannually" or "semi-annually" => "*-01,07-01 00:00",
+        "annually" or "yearly" => "*-01-01 00:00",
+        _ => s,
+    };
+
+    // weekday
+
+    private static bool IsWeekdayToken(string token)
+    {
+        var first = token.Split([',', '.'], 2)[0];
+        return Array.IndexOf(WeekdayNames, first) >= 0;
+    }
+
+    private static IReadOnlySet<int> ParseWeekdayList(string token, string original)
+    {
+        var result = new SortedSet<int>();
+        foreach (var item in token.Split(','))
+        {
+            var rangeMatch = WeekdayRangeRegex().Match(item);
+            if (rangeMatch.Success)
+            {
+                var start = Array.IndexOf(WeekdayNames, rangeMatch.Groups[1].Value);
+                var end = Array.IndexOf(WeekdayNames, rangeMatch.Groups[2].Value);
+                if (start < 0 || end < 0 || start > end)
+                {
+                    throw new PveCalendarParseException(original, $"invalid weekday range '{item}'");
+                }
+                for (var i = start; i <= end; i++) { result.Add(i); }
+            }
+            else
+            {
+                var idx = Array.IndexOf(WeekdayNames, item);
+                if (idx < 0)
+                {
+                    throw new PveCalendarParseException(original, $"invalid weekday '{item}'");
+                }
+                result.Add(idx);
+            }
+        }
+        return result;
+    }
+
+    // date spec
+
+    private static bool IsDateSpecToken(string token)
+        => token.Contains('-') && !token.Contains(':');
+
+    private static (IReadOnlySet<int> months, IReadOnlySet<int> dom) ParseDateSpec(string token, string original)
+    {
+        var parts = token.Split('-');
+        if (parts.Length is not 2 and not 3)
+        {
+            throw new PveCalendarParseException(original, $"invalid date spec '{token}'");
+        }
+
+        // 3-part: Y-M-D — only wildcard year is supported
+        if (parts.Length == 3)
+        {
+            if (parts[0] != "*")
+            {
+                throw new PveCalendarParseException(original, "fixed-year date specs are not supported (use *-MM-DD)");
+            }
+            return (ParseIntList(parts[1], 1, 12, original, "month"),
+                    ParseIntList(parts[2], 1, 31, original, "day-of-month"));
+        }
+
+        // 2-part: M-D
+        return (ParseIntList(parts[0], 1, 12, original, "month"),
+                ParseIntList(parts[1], 1, 31, original, "day-of-month"));
+    }
+
+    private static IReadOnlySet<int> ParseIntList(string token, int min, int max, string original, string fieldName)
+    {
+        if (token == "*") { return new HashSet<int>(Enumerable.Range(min, max - min + 1)); }
+
+        var result = new SortedSet<int>();
+        foreach (var item in token.Split(','))
+        {
+            ParseIntListItem(item, min, max, original, fieldName, result);
+        }
+        return result;
+    }
+
+    private static void ParseIntListItem(string item, int min, int max, string original, string fieldName, SortedSet<int> dst)
+    {
+        var step = StepRegex().Match(item);
+        if (step.Success)
+        {
+            var startStr = step.Groups[1].Value;
+            var stepVal = int.Parse(step.Groups[2].Value);
+            var start = startStr == "*" ? min : int.Parse(startStr);
+            if (start < min || start > max) { throw new PveCalendarParseException(original, $"{fieldName} '{start}' out of range [{min}..{max}]"); }
+            if (stepVal < 1) { throw new PveCalendarParseException(original, $"{fieldName} step must be >= 1"); }
+
+            for (var v = start; v <= max; v += stepVal) { dst.Add(v); }
+            return;
+        }
+
+        var range = RangeRegex().Match(item);
+        if (range.Success)
+        {
+            var lo = int.Parse(range.Groups[1].Value);
+            var hi = int.Parse(range.Groups[2].Value);
+            if (lo < min || hi > max || lo > hi)
+            {
+                throw new PveCalendarParseException(original, $"{fieldName} range '{item}' invalid for [{min}..{max}]");
+            }
+            for (var v = lo; v <= hi; v++) { dst.Add(v); }
+            return;
+        }
+
+        if (item == "*")
+        {
+            for (var v = min; v <= max; v++) { dst.Add(v); }
+            return;
+        }
+
+        if (!int.TryParse(item, out var single)) { throw new PveCalendarParseException(original, $"invalid {fieldName} token '{item}'"); }
+        if (single < min || single > max) { throw new PveCalendarParseException(original, $"{fieldName} '{single}' out of range [{min}..{max}]"); }
+        dst.Add(single);
+    }
+
+    // time HH:MM
+
+    private static (IReadOnlySet<int> hours, IReadOnlySet<int> minutes) ParseTime(string token, string original)
+    {
+        var colonIdx = token.IndexOf(':');
+        if (colonIdx < 0)
+        {
+            throw new PveCalendarParseException(original, $"time spec '{token}' must contain ':'");
+        }
+
+        var hourTok = token[..colonIdx];
+        var minTok = token[(colonIdx + 1)..];
+
+        var hours = ParseIntList(hourTok, 0, 23, original, "hour");
+        var minutes = ParseIntList(minTok, 0, 59, original, "minute");
+        return (hours, minutes);
+    }
+
+    // all-of helpers
+
+    private static IReadOnlySet<int> AllMonths() => new HashSet<int>(Enumerable.Range(1, 12));
+    private static IReadOnlySet<int> AllDaysOfMonth() => new HashSet<int>(Enumerable.Range(1, 31));
+    private static IReadOnlySet<int> AllDaysOfWeek() => new HashSet<int>(Enumerable.Range(0, 7));
+
+    [GeneratedRegex(@"^([a-z]{3})\.\.([a-z]{3})$")]
+    private static partial Regex WeekdayRangeRegex();
+
+    [GeneratedRegex(@"^(\*|[0-9]+)\/([1-9][0-9]*)$")]
+    private static partial Regex StepRegex();
+
+    [GeneratedRegex(@"^([0-9]+)\.\.([0-9]+)$")]
+    private static partial Regex RangeRegex();
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Scheduling/PveCalendarParseException.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Scheduling/PveCalendarParseException.cs
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Corsinvest.ProxmoxVE.Api.Extension.Scheduling;
+
+/// <summary>
+/// Thrown when a PVE calendar event string cannot be parsed.
+/// </summary>
+public class PveCalendarParseException(string input, string reason)
+    : Exception($"Invalid calendar event '{input}': {reason}")
+{
+    /// <summary>Original input string that failed to parse.</summary>
+    public string Input { get; } = input;
+
+    /// <summary>Human-readable reason.</summary>
+    public string Reason { get; } = reason;
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/MiscHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/Utils/MiscHelper.cs
@@ -1,172 +1,17 @@
 /*
-using System.Runtime.InteropServices;
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: MIT
  */
 
-using Corsinvest.ProxmoxVE.Api.Shared;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
 namespace Corsinvest.ProxmoxVE.Api.Extension.Utils;
 
 /// <summary>
-/// BackupHelper
+/// Misc helpers.
 /// </summary>
-public static partial class MiscHelper
+public static class MiscHelper
 {
-    //public static DateTime ParseDateBackup(string value) => DateTime.ParseExact(value, "yyyy-MM-dd HH:mm:ss", null);
-
-    /// <summary>
-    /// Day of week
-    /// </summary>
-    public static string[] DayOfWeek { get; } = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-
-    /// <summary>
-    /// Parse Calendar Event
-    /// </summary>
-    public static (string dow, string hours, string minutes) ParseCalendarEvent(string schedule)
-    {
-        var dow = DayOfWeek;
-
-        // Handle shorthands
-        schedule = schedule.Trim().ToLower() switch
-        {
-            "hourly" => "*:00",
-            "daily" => "00:00",
-            "weekly" => "mon 00:00",
-            "monthly" => "01 00:00",
-            "quarterly" => "01-01,04-01,07-01,10-01 00:00",
-            "semiannually" => "01-01,07-01 00:00",
-            "annually" or "yearly" => "01-01 00:00",
-            var s => s
-        };
-
-        var parts = schedule.Split([' '], StringSplitOptions.RemoveEmptyEntries).ToList();
-        if (parts.Count == 0) { throw new ArgumentException("Empty calendar event"); }
-
-        // Strip trailing UTC
-        if (parts[^1] == "utc") { parts.RemoveAt(parts.Count - 1); }
-
-        // --- DOW ---
-        var dowSel = string.Join("|", dow);
-        var dowHash = new List<string>();
-
-        if (parts.Count > 0 && Regex.IsMatch(parts[0], $"^({dowSel})[,.]|^({dowSel})$"))
-        {
-            foreach (var item in parts[0].Split(','))
-            {
-                var rangeMatch = Regex.Match(item, $@"^({dowSel})\.\.({dowSel})$");
-                if (rangeMatch.Success)
-                {
-                    var start = Array.IndexOf(dow, rangeMatch.Groups[1].Value);
-                    var end = Array.IndexOf(dow, rangeMatch.Groups[2].Value);
-                    if (start < 0 || end < 0) { throw new PveException($"Invalid day range: {item}"); }
-                    for (var i = start; i <= end; i++) { dowHash.Add(dow[i]); }
-                }
-                else if (Regex.IsMatch(item, $"^({dowSel})$"))
-                {
-                    dowHash.Add(item);
-                }
-                else
-                {
-                    throw new PveException($"Invalid day of week: {item}");
-                }
-            }
-            parts.RemoveAt(0);
-        }
-        else
-        {
-            dowHash.AddRange(dow);
-        }
-
-        if (parts.Count == 0) { throw new ArgumentException("Missing time specification"); }
-
-        // Date spec (e.g. 2024-01-01) — not implemented
-        if (DateSpecRegex().IsMatch(parts[0]))
-        {
-            throw new PveException("Date specification not implemented");
-        }
-
-        var matchAllHours = false;
-        var matchAllMinutes = false;
-        var hoursHash = new List<int>();
-        var minutesHash = new List<int>();
-
-        var colonIdx = parts[0].IndexOf(':');
-        if (colonIdx >= 0)
-        {
-            // HH:MM format — both sides may be lists
-            var hourPart = parts[0][..colonIdx];
-            var minutePart = parts[0][(colonIdx + 1)..];
-            foreach (var item in hourPart.Split(',')) { ParseSingleTimeSpec(item, 24, ref matchAllHours, hoursHash); }
-            foreach (var item in minutePart.Split(',')) { ParseSingleTimeSpec(item, 60, ref matchAllMinutes, minutesHash); }
-        }
-        else
-        {
-            // Only minutes specified (e.g. "*:30" already handled above; bare number = minutes)
-            matchAllHours = true;
-            foreach (var item in parts[0].Split(',')) { ParseSingleTimeSpec(item, 60, ref matchAllMinutes, minutesHash); }
-        }
-
-        return (string.Join(",", dowHash),
-                string.Join(",", matchAllHours ? Enumerable.Range(0, 24) : hoursHash.Order()),
-                string.Join(",", matchAllMinutes ? Enumerable.Range(0, 60) : minutesHash.Order()));
-    }
-
-    private static void ParseSingleTimeSpec(string item, int max, ref bool matchAll, List<int> hash)
-    {
-        var match = TimeSpecRegex().Match(item);
-        if (match.Success)
-        {
-            if (match.Groups.Count == 3 && !string.IsNullOrWhiteSpace(match.Groups[2].Value))
-            {
-                var repetition = int.Parse(match.Groups[2].Value);
-                var start = match.Groups[1].Value == "*"
-                             ? 0
-                             : int.Parse(match.Groups[1].Value);
-
-                if (start >= max) { throw new ArgumentOutOfRangeException($"Value '{start}' out of range"); }
-                if (repetition >= max) { throw new ArgumentOutOfRangeException($"Repetition  '{repetition}' out of range"); }
-
-                while (start < max)
-                {
-                    hash.Add(start);
-                    start += repetition;
-                }
-            }
-            else if (match.Groups[1].Value == "*")
-            {
-                matchAll = true;
-            }
-            else
-            {
-                var start = int.Parse(match.Groups[1].Value);
-                if (start >= max) { throw new ArgumentOutOfRangeException($"Value '{start}' out of range"); }
-                hash.Add(start);
-            }
-        }
-        else
-        {
-            match = TimeRangeRegex().Match(item);
-            if (!match.Success) { throw new ArgumentException($"Unable to parse calendar event '{item}"); }
-
-            var start = int.Parse(match.Groups[1].Value);
-            if (start >= max) { throw new ArgumentOutOfRangeException($"Range start '{start}' out of range"); }
-            var end = int.Parse(match.Groups[2].Value);
-            if (end >= max) { throw new ArgumentOutOfRangeException($"Range end '{end}' out of range"); }
-
-            for (int i = start; i <= end; i++) { hash.Add(i); }
-        }
-    }
-
-    [GeneratedRegex(@"^\d{4}-\d{2}-\d{2}$")]
-    private static partial Regex DateSpecRegex();
-    [GeneratedRegex(@"^((?:\*|[0-9]+))(?:\/([1-9][0-9]*))?$")]
-    private static partial Regex TimeSpecRegex();
-    [GeneratedRegex(@"^([0-9]+)\.\.([1-9][0-9]*)$")]
-    private static partial Regex TimeRangeRegex();
-
     /// <summary>
     /// Opens a URL in the default system browser (cross-platform).
     /// </summary>


### PR DESCRIPTION
## Summary

Replaces `MiscHelper.ParseCalendarEvent` with a dedicated `PveCalendarEvent` class that correctly handles the full PVE schedule grammar (month + day-of-month + day-of-week + hour + minute) instead of the previous 3-tuple model (dow + hour + minute).

## Fixes

Previously broken cases — now work correctly:

| Input | Before | After |
|---|---|---|
| `monthly` | bogus `hours=[0..23] minutes=[1]` | first of every month at 00:00 |
| `yearly` / `annually` | `ArgumentException` | Jan 1st at 00:00 |
| `quarterly` | `ArgumentException` | Jan/Apr/Jul/Oct 1st at 00:00 |
| `semiannually` | `ArgumentException` | Jan/Jul 1st at 00:00 |
| `*-*-* 02:00` (systemd wildcard) | `ArgumentException` | daily 02:00 |
| `*-MM-DD HH:MM` (recurring date) | `ArgumentException` | parsed correctly |
| `minutely` | missing | added |
| `2024-01-15 09:00` (fixed date) | `'Date specification not implemented'` | explicit `PveCalendarParseException` with reason "fixed-year date specs are not supported" |

## API

New namespace `Corsinvest.ProxmoxVE.Api.Extension.Scheduling`:
- `PveCalendarEvent.Parse(string)` / `TryParse(string, out)`
- `PveCalendarEvent.Matches(DateTime)`, `NextOccurrence(DateTime)`
- Properties: `Months`, `DaysOfMonth`, `DaysOfWeek`, `Hours`, `Minutes`, `Utc`, `Source`
- `PveCalendarParseException` carrying `Input` and `Reason`

## ⚠️ Breaking changes

- `MiscHelper.ParseCalendarEvent` removed (its 3-tuple return could not represent month/day-of-month; migrate to `PveCalendarEvent.Parse`)
- `MiscHelper.DayOfWeek` removed (use `PveCalendarEvent.WeekdayNames`)

## Tests

New `Corsinvest.ProxmoxVE.Api.Extension.Tests` xUnit project:
- 62 tests covering shortcuts, weekdays, time specs, date specs, error cases, `Matches` / `NextOccurrence`, common real-world PVE schedules
- ✅ all pass on net8.0 / net9.0 / net10.0 (186 total runs)

## Build

✅ Solution build green, 0 errors, 0 new warnings.