### PR TITLE
feat(shared): add NodeCapabilitiesQemu Cpu/Machine models + extension helpers

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Api.Extension/ModelsExtensionsAutoGen.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Extension/ModelsExtensionsAutoGen.cs
@@ -629,6 +629,26 @@ public static class ModelsExtensionsAutoGen
         => (await item.GetRules()).ToModel<IEnumerable<Corsinvest.ProxmoxVE.Api.Shared.Models.Common.FirewallRule>>();
 
     /// <summary>
+    /// List all custom and default CPU models.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <param name="arch">Virtual processor architecture. Defaults to the host architecture.
+    ///   Enum: x86_64,aarch64</param>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Corsinvest.ProxmoxVE.Api.Shared.Models.Node.NodeCapabilitiesQemuCpu>> GetAsync(this Corsinvest.ProxmoxVE.Api.PveClient.PveNodes.PveNodeItem.PveCapabilities.PveQemu.PveCpu item, string arch = null)
+        => (await item.Index(arch)).ToModel<IEnumerable<Corsinvest.ProxmoxVE.Api.Shared.Models.Node.NodeCapabilitiesQemuCpu>>();
+
+    /// <summary>
+    /// Get available QEMU/KVM machine types.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <param name="arch">Virtual processor architecture. Defaults to the host architecture.
+    ///   Enum: x86_64,aarch64</param>
+    /// <returns></returns>
+    public static async Task<IEnumerable<Corsinvest.ProxmoxVE.Api.Shared.Models.Node.NodeCapabilitiesQemuMachine>> GetAsync(this Corsinvest.ProxmoxVE.Api.PveClient.PveNodes.PveNodeItem.PveCapabilities.PveQemu.PveMachines item, string arch = null)
+        => (await item.Types(arch)).ToModel<IEnumerable<Corsinvest.ProxmoxVE.Api.Shared.Models.Node.NodeCapabilitiesQemuMachine>>();
+
+    /// <summary>
     /// Storage index.
     /// </summary>
     /// <param name="item"></param>

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeCapabilitiesQemuCpu.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeCapabilitiesQemuCpu.cs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+using Newtonsoft.Json;
+
+namespace Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
+
+/// <summary>
+/// QEMU CPU model exposed by the node (one entry per supported/custom CPU model).
+/// </summary>
+public class NodeCapabilitiesQemuCpu
+{
+    /// <summary>
+    /// CPU model name (e.g. "host", "kvm64", "x86-64-v2-AES").
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// CPU vendor (e.g. "Intel", "AMD").
+    /// </summary>
+    [JsonProperty("vendor")]
+    public string Vendor { get; set; }
+
+    /// <summary>
+    /// 1 if this is a custom CPU model defined via /nodes/{node}/capabilities/qemu/cpu, 0 for built-in.
+    /// </summary>
+    [JsonProperty("custom")]
+    public int Custom { get; set; }
+}

--- a/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeCapabilitiesQemuMachine.cs
+++ b/src/Corsinvest.ProxmoxVE.Api.Shared/Models/Node/NodeCapabilitiesQemuMachine.cs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+using Newtonsoft.Json;
+
+namespace Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
+
+/// <summary>
+/// QEMU machine type available on the node (one entry per supported machine).
+/// </summary>
+public class NodeCapabilitiesQemuMachine
+{
+    /// <summary>
+    /// Full machine identifier (e.g. "pc-i440fx-8.0", "pc-q35-9.2", "pc-i440fx-latest").
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Machine family (e.g. "i440fx", "q35").
+    /// </summary>
+    [JsonProperty("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// QEMU version of the machine type (e.g. "8.0").
+    /// </summary>
+    [JsonProperty("version")]
+    public string Version { get; set; }
+
+    /// <summary>
+    /// Optional human-readable changelog / notes for this machine version.
+    /// </summary>
+    [JsonProperty("changes")]
+    public string Changes { get; set; }
+}


### PR DESCRIPTION
## Summary

Adds the typed models and `GetAsync` extension helpers for the QEMU capabilities endpoints introduced by the schema regeneration in #84.

## Endpoints covered

| Endpoint | Model | Helper |
|---|---|---|
| `GET /nodes/{node}/capabilities/qemu/cpu` | `NodeCapabilitiesQemuCpu` | `Capabilities.Qemu.Cpu.GetAsync()` |
| `GET /nodes/{node}/capabilities/qemu/machines` | `NodeCapabilitiesQemuMachine` | `Capabilities.Qemu.Machines.GetAsync()` |

## Changes

- `NodeCapabilitiesQemuCpu`: `Name`, `Vendor`, `Custom`
- `NodeCapabilitiesQemuMachine`: `Id`, `Type`, `Version`, `Changes`
- 2 new `GetAsync` overloads in `ModelsExtensionsAutoGen`, both supporting the optional `arch` parameter (`x86_64` / `aarch64`)

## Build

✅ green, 0 errors, no new warnings.